### PR TITLE
Pin pymc to v6 branch for early testing

### DIFF
--- a/decision-packs/mmm/docker/Dockerfile
+++ b/decision-packs/mmm/docker/Dockerfile
@@ -18,8 +18,6 @@ RUN conda install -y \
     scikit-learn=1.8.0 \
     statsmodels=0.14.6 \
     arviz=0.23.1 \
-    pymc=5.26.1 \
-    pytensor=2.35.1 \
     pyyaml=6.0.3 \
     && conda clean -afy
 
@@ -32,6 +30,7 @@ RUN conda install -y \
 # xarray/h5py pinned to match Modal app for cloudpickle compatibility
 # modal for cloud MCMC fitting
 RUN pip install --no-cache-dir \
+    "pymc @ git+https://github.com/pymc-devs/pymc.git@v6" \
     numpy==2.3.5 \
     pyarrow==23.0.0 \
     pymc-marketing==0.18.0 \

--- a/decision-packs/mmm/environment.yaml
+++ b/decision-packs/mmm/environment.yaml
@@ -20,13 +20,12 @@ dependencies:
   - statsmodels=0.14.6
   # Bayesian
   - arviz=0.23.1
-  - pymc=5.26.1
-  - pytensor=2.35.1
   # Utils
   - pyyaml=6.0.3
   # Pip packages (must be via pip for Coiled package sync compatibility)
   - pip
   - pip:
+    - "pymc @ git+https://github.com/pymc-devs/pymc.git@v6"
     - numpy==2.3.5
     - pyarrow==23.0.0
     - pymc-marketing==0.18.0

--- a/decision-packs/mmm/tests/fixtures/pyproject.toml
+++ b/decision-packs/mmm/tests/fixtures/pyproject.toml
@@ -21,8 +21,7 @@ dependencies = [
     "scikit-learn==1.8.0",
     "statsmodels==0.14.6",
     "arviz==0.23.1",
-    "pymc==5.26.1",
-    "pytensor==2.35.1",
+    "pymc @ git+https://github.com/pymc-devs/pymc.git@v6",
     "pyyaml==6.0.3",
 
     # From pip


### PR DESCRIPTION
## Summary
- Move pymc from conda to pip install with `git+https` URL pointing at the v6 branch
- Remove pytensor pin so PyMC v6 can resolve its own version (v6 requires pytensor ≥2.38)
- Applied across Dockerfile, environment.yaml, and tests/fixtures/pyproject.toml

## Notes
- pymc-marketing 0.18.0 confirmed compatible with PyMC v6 (tested separately)
- PyTensor's g++ warning is cosmetic when using numba backend (see https://github.com/pymc-devs/pytensor/issues/1995)

## Test plan
- [ ] Docker build completes successfully
- [ ] `MultidimensionalMMM` import works
- [ ] MCMC sampling runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)