### PR TITLE
Add web-based session viewer

### DIFF
--- a/viewer/.gitignore
+++ b/viewer/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/viewer/demo-session/.state.json
+++ b/viewer/demo-session/.state.json
@@ -1,0 +1,10 @@
+{
+  "work_dir": "/sessions/dlab-analysis-001",
+  "config_dir": "/decision-packs/mmm",
+  "dpack_name": "mmm",
+  "status": "completed",
+  "started_at": "2026-03-22T14:30:00Z",
+  "completed_at": "2026-03-22T15:47:23Z",
+  "prompt": "Analyze our marketing spend data to understand channel ROI and optimize our Q2 2026 budget allocation. We spend roughly $2.4M/month across TV, Digital, Social, Search, and Print. We want to know which channels are saturated and where to reallocate.",
+  "model": "anthropic/claude-sonnet-4-6"
+}

--- a/viewer/demo-session/budget_20pct/optimization_summary.json
+++ b/viewer/demo-session/budget_20pct/optimization_summary.json
@@ -1,0 +1,21 @@
+{
+  "risk_level": "20%",
+  "bounds": "±20% of current spend",
+  "total_budget": 2400000,
+  "expected_uplift_pct": 8.3,
+  "expected_additional_revenue": 662400,
+  "allocation": {
+    "tv": {"current": 680000, "optimized": 578000, "change_pct": -15.0},
+    "digital": {"current": 520000, "optimized": 468000, "change_pct": -10.0},
+    "social": {"current": 380000, "optimized": 456000, "change_pct": 20.0},
+    "search": {"current": 440000, "optimized": 484000, "change_pct": 10.0},
+    "print": {"current": 180000, "optimized": 144000, "change_pct": -20.0}
+  },
+  "key_moves": [
+    "Increase Social by 20% ($76K) — lowest saturation, strong ROAS",
+    "Increase Search by 10% ($44K) — highest ROAS despite high saturation",
+    "Decrease TV by 15% ($102K) — high saturation, moderate ROAS",
+    "Decrease Print by 20% ($36K) — lowest ROAS, limited impact",
+    "Decrease Digital by 10% ($52K) — approaching saturation ceiling"
+  ]
+}

--- a/viewer/demo-session/conflict_detection.md
+++ b/viewer/demo-session/conflict_detection.md
@@ -1,0 +1,38 @@
+# Conflict Detection Report
+
+## Models Evaluated
+All 3 model instances converged successfully.
+
+## Check 1: ROAS Variation (< 5x threshold)
+| Channel | Min ROAS | Max ROAS | Ratio | Status |
+|---------|----------|----------|-------|--------|
+| TV | 2.18 | 2.58 | 1.18x | ✅ Pass |
+| Digital | 3.62 | 3.95 | 1.09x | ✅ Pass |
+| Social | 2.76 | 3.21 | 1.16x | ✅ Pass |
+| Search | 3.89 | 4.28 | 1.10x | ✅ Pass |
+| Print | 1.08 | 1.41 | 1.31x | ✅ Pass |
+
+**Result**: ✅ All channels within acceptable variation range.
+
+## Check 2: Directional Agreement
+All models agree on the sign and relative magnitude of all channel effects.
+- All channels show positive ROAS across all models
+- No directional disagreements detected
+
+**Result**: ✅ Full directional agreement.
+
+## Check 3: Top 5 Channel Ranking Consistency
+| Rank | Instance 1 | Instance 2 | Instance 3 |
+|------|-----------|-----------|-----------|
+| 1 | Search | Search | Search |
+| 2 | Digital | Digital | Digital |
+| 3 | Social | Social | Social |
+| 4 | TV | TV | TV |
+| 5 | Print | Print | Print |
+
+**Result**: ✅ Identical ranking across all models.
+
+## Overall Verdict
+**✅ NO CONFLICTS DETECTED** — Proceeding to model selection and budget optimization.
+
+Models show remarkable consistency despite different adstock formulations and data cleaning approaches, which strengthens confidence in the results.

--- a/viewer/demo-session/data_summary.md
+++ b/viewer/demo-session/data_summary.md
@@ -1,0 +1,44 @@
+# Data Exploration Summary
+
+## Dataset Overview
+- **File**: `marketing_spend_weekly.csv`
+- **Rows**: 156 (3 years of weekly data, 2023-01 to 2025-12)
+- **Columns**: 12
+
+## Target Variable
+- **`revenue`**: Weekly revenue in USD
+  - Mean: $8.2M | Median: $7.9M | Std: $2.1M
+  - No missing values
+  - Mild right skew (0.34)
+
+## Channel Spend Columns (5 channels)
+| Channel | Weekly Mean | Weekly Median | % Zero Weeks | Correlation w/ Revenue |
+|---------|-----------|--------------|-------------|----------------------|
+| tv_spend | $680K | $720K | 2.6% | 0.61 |
+| digital_spend | $520K | $510K | 0% | 0.73 |
+| social_spend | $380K | $360K | 0% | 0.58 |
+| search_spend | $440K | $430K | 0% | 0.69 |
+| print_spend | $180K | $170K | 8.3% | 0.31 |
+
+## Control Variables
+| Variable | Description | Type |
+|----------|-------------|------|
+| `price_index` | Relative price vs competitors | Continuous (0.85–1.15) |
+| `seasonality_index` | Holiday/seasonal multiplier | Continuous (0.7–1.4) |
+| `competitor_spend` | Estimated competitor total spend | Continuous ($1.2M–$3.8M) |
+| `trend` | Linear time trend | Integer (1–156) |
+
+## Data Quality
+- **Missing values**: 3 missing in `competitor_spend` (weeks 45, 89, 112) — interpolated
+- **Outliers**: Week 52 (Christmas) shows 2.3x typical revenue — legitimate seasonal spike
+- **Stationarity**: Revenue is trend-stationary after detrending (ADF p=0.003)
+- **Multicollinearity**: VIF < 3 for all channels after removing trend. TV and Digital show moderate correlation (r=0.42)
+
+## Parameter Count Assessment
+- With 5 channels × (alpha + lmax + lambda + beta) = 20 channel params + 4 control betas + intercept + sigma = 26 parameters
+- 156 observations → ~6:1 ratio — sufficient but tight. Recommend informative priors.
+
+## Recommendation
+Data is suitable for MMM analysis. Recommend two data preparation approaches:
+1. **Minimal cleaning**: Interpolate missing competitor_spend, keep all 156 weeks
+2. **Conservative cleaning**: Drop first 8 weeks (potential cold-start), cap outliers at 95th percentile

--- a/viewer/demo-session/instance-1/analysis_output/analysis_summary.json
+++ b/viewer/demo-session/instance-1/analysis_output/analysis_summary.json
@@ -1,0 +1,39 @@
+{
+  "model_name": "Standard Saturating MMM (Geometric Adstock)",
+  "instance": 1,
+  "convergence": {
+    "converged": true,
+    "rhat_max": 1.003,
+    "ess_bulk_min": 1847,
+    "ess_tail_min": 1421,
+    "divergences": 0,
+    "total_draws": 8000
+  },
+  "fit_quality": {
+    "r2_in_sample": 0.91,
+    "mape": 0.068,
+    "r2_out_of_sample": 0.84
+  },
+  "roas": {
+    "tv": {"mean": 2.31, "sd": 0.42, "hdi_low": 1.58, "hdi_high": 3.12},
+    "digital": {"mean": 3.87, "sd": 0.61, "hdi_low": 2.74, "hdi_high": 5.03},
+    "social": {"mean": 2.94, "sd": 0.55, "hdi_low": 1.92, "hdi_high": 3.98},
+    "search": {"mean": 4.12, "sd": 0.73, "hdi_low": 2.78, "hdi_high": 5.51},
+    "print": {"mean": 1.23, "sd": 0.38, "hdi_low": 0.52, "hdi_high": 1.94}
+  },
+  "saturation": {
+    "tv": 0.67,
+    "digital": 0.78,
+    "social": 0.52,
+    "search": 0.81,
+    "print": 0.41
+  },
+  "adstock_halflife_weeks": {
+    "tv": 3.2,
+    "digital": 1.1,
+    "social": 0.8,
+    "search": 0.5,
+    "print": 2.8
+  },
+  "runtime_seconds": 342
+}

--- a/viewer/demo-session/instance-1/summary.md
+++ b/viewer/demo-session/instance-1/summary.md
@@ -1,0 +1,40 @@
+# Model Instance 1: Standard Saturating MMM (Geometric Adstock)
+
+## Configuration
+- **Adstock**: Geometric decay
+- **Saturation**: Logistic
+- **Data**: Full 156 weeks, minimal cleaning
+- **Sampler**: NUTS (JAX/numpyro), 4 chains × 2000 draws (1000 warmup)
+
+## Convergence
+- **Status**: ✅ Converged
+- **Max R-hat**: 1.003 (all params < 1.01)
+- **Min ESS (bulk)**: 1,847
+- **Min ESS (tail)**: 1,421
+- **Divergences**: 0/8000
+
+## Fit Quality
+- **In-sample R²**: 0.91
+- **MAPE**: 6.8%
+- **Out-of-sample R² (last 12 weeks)**: 0.84
+
+## Key Findings
+
+### ROAS Estimates (Posterior Mean ± SD)
+| Channel | ROAS | 94% HDI |
+|---------|------|---------|
+| TV | 2.31 ± 0.42 | [1.58, 3.12] |
+| Digital | 3.87 ± 0.61 | [2.74, 5.03] |
+| Social | 2.94 ± 0.55 | [1.92, 3.98] |
+| Search | 4.12 ± 0.73 | [2.78, 5.51] |
+| Print | 1.23 ± 0.38 | [0.52, 1.94] |
+
+### Saturation Analysis
+- **TV**: Operating at 67% saturation — moderate room for growth
+- **Digital**: Operating at 78% saturation — approaching diminishing returns
+- **Social**: Operating at 52% saturation — significant room for growth
+- **Search**: Operating at 81% saturation — highly saturated
+- **Print**: Operating at 41% saturation — low saturation but also low ROAS
+
+### Adstock Half-lives
+- TV: 3.2 weeks | Digital: 1.1 weeks | Social: 0.8 weeks | Search: 0.5 weeks | Print: 2.8 weeks

--- a/viewer/demo-session/instance-2/analysis_output/analysis_summary.json
+++ b/viewer/demo-session/instance-2/analysis_output/analysis_summary.json
@@ -1,0 +1,32 @@
+{
+  "model_name": "Flexible Adstock MMM (Weibull CDF)",
+  "instance": 2,
+  "convergence": {
+    "converged": true,
+    "rhat_max": 1.006,
+    "ess_bulk_min": 1203,
+    "ess_tail_min": 987,
+    "divergences": 12,
+    "total_draws": 8000
+  },
+  "fit_quality": {
+    "r2_in_sample": 0.93,
+    "mape": 0.059,
+    "r2_out_of_sample": 0.86
+  },
+  "roas": {
+    "tv": {"mean": 2.58, "sd": 0.51, "hdi_low": 1.67, "hdi_high": 3.54},
+    "digital": {"mean": 3.62, "sd": 0.58, "hdi_low": 2.54, "hdi_high": 4.72},
+    "social": {"mean": 3.21, "sd": 0.63, "hdi_low": 2.04, "hdi_high": 4.41},
+    "search": {"mean": 3.89, "sd": 0.68, "hdi_low": 2.63, "hdi_high": 5.20},
+    "print": {"mean": 1.41, "sd": 0.44, "hdi_low": 0.59, "hdi_high": 2.24}
+  },
+  "saturation": {
+    "tv": 0.61,
+    "digital": 0.74,
+    "social": 0.48,
+    "search": 0.79,
+    "print": 0.38
+  },
+  "runtime_seconds": 487
+}

--- a/viewer/demo-session/instance-2/summary.md
+++ b/viewer/demo-session/instance-2/summary.md
@@ -1,0 +1,49 @@
+# Model Instance 2: Flexible Adstock MMM (Weibull CDF)
+
+## Configuration
+- **Adstock**: Weibull CDF (flexible peak timing)
+- **Saturation**: Logistic
+- **Data**: Full 156 weeks, minimal cleaning
+- **Sampler**: NUTS (JAX/numpyro), 4 chains × 2000 draws (1000 warmup)
+
+## Convergence
+- **Status**: ✅ Converged
+- **Max R-hat**: 1.006
+- **Min ESS (bulk)**: 1,203
+- **Min ESS (tail)**: 987
+- **Divergences**: 12/8000 (0.15% — acceptable)
+
+## Fit Quality
+- **In-sample R²**: 0.93
+- **MAPE**: 5.9%
+- **Out-of-sample R² (last 12 weeks)**: 0.86
+
+## Key Findings
+
+### ROAS Estimates (Posterior Mean ± SD)
+| Channel | ROAS | 94% HDI |
+|---------|------|---------|
+| TV | 2.58 ± 0.51 | [1.67, 3.54] |
+| Digital | 3.62 ± 0.58 | [2.54, 4.72] |
+| Social | 3.21 ± 0.63 | [2.04, 4.41] |
+| Search | 3.89 ± 0.68 | [2.63, 5.20] |
+| Print | 1.41 ± 0.44 | [0.59, 2.24] |
+
+### Saturation Analysis
+- **TV**: Operating at 61% saturation
+- **Digital**: Operating at 74% saturation
+- **Social**: Operating at 48% saturation
+- **Search**: Operating at 79% saturation
+- **Print**: Operating at 38% saturation
+
+### Adstock (Weibull Parameters)
+- TV: shape=1.8, scale=4.1 (peak at ~2 weeks, long tail)
+- Digital: shape=2.3, scale=1.4 (sharp peak at ~1 week)
+- Social: shape=2.1, scale=1.0 (sharp peak, fast decay)
+- Search: shape=3.2, scale=0.7 (very sharp, immediate)
+- Print: shape=1.4, scale=3.8 (slow build, peak ~2.5 weeks)
+
+### Notable Differences from Instance 1
+- Weibull captures TV's delayed peak effect better — TV ROAS slightly higher
+- Social benefits from flexible decay shape — ROAS bumped up
+- Overall better fit (R² 0.93 vs 0.91) with only slightly more parameters

--- a/viewer/demo-session/instance-3/analysis_output/analysis_summary.json
+++ b/viewer/demo-session/instance-3/analysis_output/analysis_summary.json
@@ -1,0 +1,32 @@
+{
+  "model_name": "Conservative Data + Geometric Adstock",
+  "instance": 3,
+  "convergence": {
+    "converged": true,
+    "rhat_max": 1.002,
+    "ess_bulk_min": 2104,
+    "ess_tail_min": 1678,
+    "divergences": 0,
+    "total_draws": 8000
+  },
+  "fit_quality": {
+    "r2_in_sample": 0.89,
+    "mape": 0.072,
+    "r2_out_of_sample": 0.83
+  },
+  "roas": {
+    "tv": {"mean": 2.18, "sd": 0.39, "hdi_low": 1.49, "hdi_high": 2.92},
+    "digital": {"mean": 3.95, "sd": 0.57, "hdi_low": 2.89, "hdi_high": 5.04},
+    "social": {"mean": 2.76, "sd": 0.48, "hdi_low": 1.87, "hdi_high": 3.68},
+    "search": {"mean": 4.28, "sd": 0.65, "hdi_low": 3.06, "hdi_high": 5.52},
+    "print": {"mean": 1.08, "sd": 0.35, "hdi_low": 0.43, "hdi_high": 1.73}
+  },
+  "saturation": {
+    "tv": 0.70,
+    "digital": 0.76,
+    "social": 0.55,
+    "search": 0.83,
+    "print": 0.43
+  },
+  "runtime_seconds": 298
+}

--- a/viewer/demo-session/instance-3/summary.md
+++ b/viewer/demo-session/instance-3/summary.md
@@ -1,0 +1,43 @@
+# Model Instance 3: Conservative Data + Geometric Adstock
+
+## Configuration
+- **Adstock**: Geometric decay
+- **Saturation**: Logistic
+- **Data**: 148 weeks (conservative cleaning, dropped first 8 weeks + outlier capping)
+- **Sampler**: NUTS (JAX/numpyro), 4 chains × 2000 draws (1000 warmup)
+
+## Convergence
+- **Status**: ✅ Converged
+- **Max R-hat**: 1.002
+- **Min ESS (bulk)**: 2,104
+- **Min ESS (tail)**: 1,678
+- **Divergences**: 0/8000
+
+## Fit Quality
+- **In-sample R²**: 0.89
+- **MAPE**: 7.2%
+- **Out-of-sample R² (last 12 weeks)**: 0.83
+
+## Key Findings
+
+### ROAS Estimates (Posterior Mean ± SD)
+| Channel | ROAS | 94% HDI |
+|---------|------|---------|
+| TV | 2.18 ± 0.39 | [1.49, 2.92] |
+| Digital | 3.95 ± 0.57 | [2.89, 5.04] |
+| Social | 2.76 ± 0.48 | [1.87, 3.68] |
+| Search | 4.28 ± 0.65 | [3.06, 5.52] |
+| Print | 1.08 ± 0.35 | [0.43, 1.73] |
+
+### Saturation Analysis
+- **TV**: Operating at 70% saturation
+- **Digital**: Operating at 76% saturation
+- **Social**: Operating at 55% saturation
+- **Search**: Operating at 83% saturation
+- **Print**: Operating at 43% saturation
+
+### Notes
+- Tighter priors led to narrower posteriors (lower SD across the board)
+- Slightly lower R² due to fewer data points but better convergence metrics
+- ROAS rankings consistent with Instance 1: Search > Digital > Social > TV > Print
+- Removing early weeks reduced TV ROAS slightly (early brand-building period removed)

--- a/viewer/demo-session/model_selection.md
+++ b/viewer/demo-session/model_selection.md
@@ -1,0 +1,13 @@
+# Model Selection
+
+## Selected Model: Instance 2 (Flexible Adstock MMM — Weibull CDF)
+
+### Rationale
+1. **Best fit quality**: R² = 0.93 (vs 0.91, 0.89), MAPE = 5.9% (vs 6.8%, 7.2%)
+2. **Good convergence**: All R-hat < 1.01, 12 divergences out of 8000 draws (0.15%) is acceptable
+3. **Captures delayed effects**: Weibull adstock better represents TV's delayed peak and Print's slow build
+4. **Consistent with ensemble**: ROAS estimates fall within the range of all three models
+5. **Out-of-sample performance**: Best holdout R² = 0.86
+
+### Trade-off Considered
+Instance 3 had the best convergence diagnostics (0 divergences, highest ESS), but its slightly lower fit quality and the loss of 8 weeks of data made it less suitable as the primary model. Its tight agreement with Instance 2 validates the Weibull model's estimates.

--- a/viewer/demo-session/modeling_plans.md
+++ b/viewer/demo-session/modeling_plans.md
@@ -1,0 +1,24 @@
+# Modeling Plans
+
+Based on data exploration, I propose 3 modeling strategies to run in parallel:
+
+## Plan 1: Standard Saturating MMM (Geometric Adstock)
+- **Data prep**: Approach 1 (minimal cleaning, all 156 weeks)
+- **Adstock**: Geometric decay per channel
+- **Saturation**: Logistic per channel
+- **Priors**: Moderately informative (industry benchmarks)
+- **Rationale**: Baseline model, well-understood behavior
+
+## Plan 2: Flexible Adstock MMM (Weibull CDF)
+- **Data prep**: Approach 1 (minimal cleaning, all 156 weeks)
+- **Adstock**: Weibull CDF (more flexible peak timing)
+- **Saturation**: Logistic per channel
+- **Priors**: Moderately informative, wider on adstock shape
+- **Rationale**: TV and Print may have delayed peak effects that geometric can't capture
+
+## Plan 3: Conservative Data + Geometric Adstock
+- **Data prep**: Approach 2 (conservative cleaning, 148 weeks)
+- **Adstock**: Geometric decay per channel
+- **Saturation**: Logistic per channel
+- **Priors**: Informative (tighter bounds from prior studies)
+- **Rationale**: Test sensitivity to data cleaning choices and prior strength

--- a/viewer/demo-session/report.md
+++ b/viewer/demo-session/report.md
@@ -1,0 +1,38 @@
+# Marketing Mix Model — Executive Report
+
+## Overview
+We analyzed 3 years of weekly marketing data (156 weeks) across 5 channels to understand channel ROI and optimize Q2 2026 budget allocation. Three independent modeling approaches were run in parallel and cross-validated — all agreed on the key findings below.
+
+## Key Findings
+
+### Channel Performance (Return on Ad Spend)
+1. **Search** ($4.12 per $1 spent) — Highest ROI but highly saturated (79%). Additional spend yields diminishing returns.
+2. **Digital** ($3.62 per $1 spent) — Strong performer, approaching saturation (74%).
+3. **Social** ($3.21 per $1 spent) — Strong ROI with significant room to grow (only 48% saturated).
+4. **TV** ($2.58 per $1 spent) — Moderate ROI with delayed effects (peaks ~2 weeks after airing). Moderately saturated (61%).
+5. **Print** ($1.41 per $1 spent) — Lowest ROI. Slow to build, limited impact.
+
+### The Opportunity
+**Social media is your biggest growth lever.** At only 48% saturation with a ROAS of 3.2x, every additional dollar in Social works nearly twice as hard as the same dollar in Search (which is 79% saturated). Meanwhile, Print's low returns suggest budget could be better deployed elsewhere.
+
+## Budget Recommendation (±20% Reallocation)
+Keeping total monthly budget at $2.4M:
+
+| Channel | Current | Recommended | Change |
+|---------|---------|-------------|--------|
+| TV | $680K | $578K | -15% |
+| Digital | $520K | $468K | -10% |
+| Social | $380K | $456K | **+20%** |
+| Search | $440K | $484K | +10% |
+| Print | $180K | $144K | -20% |
+
+**Expected impact**: +8.3% revenue uplift (~$662K/month additional revenue) with zero incremental spend.
+
+## Confidence & Caveats
+- **High confidence**: Three independent models (different adstock formulations, data cleaning approaches) produced consistent rankings and similar ROAS estimates
+- **Model fit**: R² = 0.93, MAPE = 5.9% — strong predictive accuracy
+- **Caveat**: Model assumes historical relationships persist. Major competitive shifts or market changes may alter channel effectiveness
+- **Caveat**: Print may serve brand-building functions not fully captured by short-term revenue attribution
+
+## Methodology
+Bayesian Media Mix Model using PyMC-Marketing with Weibull adstock transformations and logistic saturation curves. Fitted via NUTS sampler (4 chains × 2000 draws). All convergence diagnostics passed. Full technical details in the companion technical report.

--- a/viewer/demo-session/session_manifest.json
+++ b/viewer/demo-session/session_manifest.json
@@ -1,0 +1,153 @@
+{
+  "session_id": "dlab-analysis-001",
+  "dpack": "mmm",
+  "prompt": "Analyze our marketing spend data to understand channel ROI and optimize our Q2 2026 budget allocation. We spend roughly $2.4M/month across TV, Digital, Social, Search, and Print. We want to know which channels are saturated and where to reallocate.",
+  "model": "anthropic/claude-sonnet-4-6",
+  "started_at": "2026-03-22T14:30:00Z",
+  "completed_at": "2026-03-22T15:47:23Z",
+  "status": "completed",
+  "workflow": [
+    {
+      "id": "start",
+      "label": "Session Start",
+      "agent": "orchestrator",
+      "status": "completed",
+      "started_at": "2026-03-22T14:30:00Z",
+      "completed_at": "2026-03-22T14:30:05Z",
+      "children": ["explore"]
+    },
+    {
+      "id": "explore",
+      "label": "Data Exploration",
+      "agent": "data-explorer",
+      "status": "completed",
+      "started_at": "2026-03-22T14:30:05Z",
+      "completed_at": "2026-03-22T14:34:18Z",
+      "artifacts": ["data_summary.md"],
+      "children": ["dataprep-1", "dataprep-2"]
+    },
+    {
+      "id": "dataprep-1",
+      "label": "Data Prep: Minimal Cleaning",
+      "agent": "data-preparer",
+      "instance": 1,
+      "parallel_group": "data-prep",
+      "status": "completed",
+      "started_at": "2026-03-22T14:34:18Z",
+      "completed_at": "2026-03-22T14:38:42Z",
+      "artifacts": [],
+      "children": ["consolidate"]
+    },
+    {
+      "id": "dataprep-2",
+      "label": "Data Prep: Conservative Cleaning",
+      "agent": "data-preparer",
+      "instance": 2,
+      "parallel_group": "data-prep",
+      "status": "completed",
+      "started_at": "2026-03-22T14:34:18Z",
+      "completed_at": "2026-03-22T14:39:11Z",
+      "artifacts": [],
+      "children": ["consolidate"]
+    },
+    {
+      "id": "consolidate",
+      "label": "Consolidate & Plan Models",
+      "agent": "orchestrator",
+      "status": "completed",
+      "started_at": "2026-03-22T14:39:11Z",
+      "completed_at": "2026-03-22T14:42:30Z",
+      "artifacts": ["modeling_plans.md"],
+      "children": ["model-1", "model-2", "model-3"]
+    },
+    {
+      "id": "model-1",
+      "label": "Model 1: Geometric Adstock",
+      "agent": "modeler",
+      "instance": 1,
+      "parallel_group": "modeling",
+      "status": "completed",
+      "started_at": "2026-03-22T14:42:30Z",
+      "completed_at": "2026-03-22T14:48:12Z",
+      "duration_seconds": 342,
+      "artifacts": ["instance-1/summary.md", "instance-1/analysis_output/analysis_summary.json"],
+      "metrics": {
+        "r2": 0.91,
+        "mape": 0.068,
+        "converged": true,
+        "divergences": 0
+      },
+      "children": ["conflict"]
+    },
+    {
+      "id": "model-2",
+      "label": "Model 2: Weibull Adstock",
+      "agent": "modeler",
+      "instance": 2,
+      "parallel_group": "modeling",
+      "status": "completed",
+      "started_at": "2026-03-22T14:42:30Z",
+      "completed_at": "2026-03-22T14:50:37Z",
+      "duration_seconds": 487,
+      "artifacts": ["instance-2/summary.md", "instance-2/analysis_output/analysis_summary.json"],
+      "metrics": {
+        "r2": 0.93,
+        "mape": 0.059,
+        "converged": true,
+        "divergences": 12
+      },
+      "children": ["conflict"],
+      "selected": true
+    },
+    {
+      "id": "model-3",
+      "label": "Model 3: Conservative + Geometric",
+      "agent": "modeler",
+      "instance": 3,
+      "parallel_group": "modeling",
+      "status": "completed",
+      "started_at": "2026-03-22T14:42:30Z",
+      "completed_at": "2026-03-22T14:47:28Z",
+      "duration_seconds": 298,
+      "artifacts": ["instance-3/summary.md", "instance-3/analysis_output/analysis_summary.json"],
+      "metrics": {
+        "r2": 0.89,
+        "mape": 0.072,
+        "converged": true,
+        "divergences": 0
+      },
+      "children": ["conflict"]
+    },
+    {
+      "id": "conflict",
+      "label": "Conflict Detection",
+      "agent": "orchestrator",
+      "status": "completed",
+      "started_at": "2026-03-22T14:50:37Z",
+      "completed_at": "2026-03-22T14:53:15Z",
+      "artifacts": ["conflict_detection.md", "model_selection.md"],
+      "result": "no_conflict",
+      "children": ["optimize"]
+    },
+    {
+      "id": "optimize",
+      "label": "Budget Optimization",
+      "agent": "orchestrator",
+      "status": "completed",
+      "started_at": "2026-03-22T14:53:15Z",
+      "completed_at": "2026-03-22T15:02:44Z",
+      "artifacts": ["budget_20pct/optimization_summary.json"],
+      "children": ["reports"]
+    },
+    {
+      "id": "reports",
+      "label": "Final Reports",
+      "agent": "orchestrator",
+      "status": "completed",
+      "started_at": "2026-03-22T15:02:44Z",
+      "completed_at": "2026-03-22T15:47:23Z",
+      "artifacts": ["report.md", "technical_report.md"],
+      "children": []
+    }
+  ]
+}

--- a/viewer/demo-session/technical_report.md
+++ b/viewer/demo-session/technical_report.md
@@ -1,0 +1,104 @@
+# Marketing Mix Model — Technical Report
+
+## 1. Data
+- **Source**: `marketing_spend_weekly.csv` — 156 weeks (2023-W01 to 2025-W52)
+- **Target**: Weekly revenue (USD)
+- **Channels**: TV, Digital, Social, Search, Print (weekly spend)
+- **Controls**: price_index, seasonality_index, competitor_spend, trend
+- **Preprocessing**: 3 missing competitor_spend values interpolated. No non-linear transforms applied to channels or target.
+
+## 2. Model Specification (Selected: Instance 2)
+
+### Likelihood
+```
+revenue ~ Normal(μ, σ)
+μ = intercept + Σ(channel_contributions) + Σ(control_effects)
+```
+
+### Channel Contribution
+```
+channel_contribution_c = β_c × saturation(adstock(spend_c))
+adstock: Weibull CDF with shape_c, scale_c parameters
+saturation: Logistic with lambda_c, L_c parameters
+```
+
+### Priors
+| Parameter | Prior | Rationale |
+|-----------|-------|-----------|
+| intercept | Normal(8e6, 2e6) | Centered on mean revenue |
+| β_channel | HalfNormal(σ=2) | Positive channel effects |
+| weibull_shape | Gamma(α=2, β=1) | Flexible, peaks around 2 |
+| weibull_scale | Gamma(α=2, β=0.5) | Weeks, channel-specific |
+| saturation_lambda | Beta(α=2, β=2) | Mid-range default |
+| saturation_L | HalfNormal(σ=3) | Channel capacity |
+| β_control | Normal(0, 1) | Weakly informative |
+| σ | HalfNormal(σ=1e6) | Observation noise |
+
+### l_max Settings
+- TV: 13 | Digital: 6 | Social: 4 | Search: 4 | Print: 8
+
+## 3. Inference
+- **Sampler**: NUTS via JAX/NumPyro backend
+- **Chains**: 4
+- **Draws**: 2000 per chain (1000 warmup)
+- **Total posterior samples**: 4000
+- **Runtime**: 487 seconds
+
+## 4. Convergence Diagnostics
+
+| Metric | Value | Threshold | Status |
+|--------|-------|-----------|--------|
+| Max R-hat | 1.006 | < 1.01 | ✅ |
+| Min ESS (bulk) | 1,203 | > 400 | ✅ |
+| Min ESS (tail) | 987 | > 400 | ✅ |
+| Divergences | 12/8000 | < 1% | ✅ |
+| Energy BFMI | 0.94 | > 0.3 | ✅ |
+
+## 5. Posterior Estimates
+
+### Channel ROAS
+| Channel | Mean | SD | HDI 3% | HDI 97% |
+|---------|------|----|--------|---------|
+| TV | 2.58 | 0.51 | 1.67 | 3.54 |
+| Digital | 3.62 | 0.58 | 2.54 | 4.72 |
+| Social | 3.21 | 0.63 | 2.04 | 4.41 |
+| Search | 3.89 | 0.68 | 2.63 | 5.20 |
+| Print | 1.41 | 0.44 | 0.59 | 2.24 |
+
+### Adstock Parameters (Weibull)
+| Channel | Shape (mean) | Scale (mean) | Implied Peak Week |
+|---------|-------------|-------------|-------------------|
+| TV | 1.8 | 4.1 | ~2.0 |
+| Digital | 2.3 | 1.4 | ~1.0 |
+| Social | 2.1 | 1.0 | ~0.7 |
+| Search | 3.2 | 0.7 | ~0.5 |
+| Print | 1.4 | 3.8 | ~2.5 |
+
+### Saturation Operating Points
+| Channel | Current Saturation | Spend at 90% Sat | Headroom |
+|---------|-------------------|-------------------|----------|
+| TV | 61% | $1.12M/wk | Moderate |
+| Digital | 74% | $780K/wk | Limited |
+| Social | 48% | $820K/wk | Large |
+| Search | 79% | $580K/wk | Very Limited |
+| Print | 38% | $490K/wk | Large (but low ROAS) |
+
+## 6. Model Comparison
+
+| Metric | Instance 1 (Geo) | Instance 2 (Weibull) | Instance 3 (Geo+Conservative) |
+|--------|------------------|---------------------|------------------------------|
+| R² (in-sample) | 0.91 | **0.93** | 0.89 |
+| MAPE | 6.8% | **5.9%** | 7.2% |
+| R² (holdout) | 0.84 | **0.86** | 0.83 |
+| Divergences | 0 | 12 | 0 |
+| Max R-hat | 1.003 | 1.006 | 1.002 |
+
+Instance 2 selected for best fit quality with acceptable convergence.
+
+## 7. Conflict Detection
+All three models produced consistent ROAS rankings (Search > Digital > Social > TV > Print) with max variation ratio of 1.31x (Print). No directional disagreements. Ensemble agreement strengthens confidence in recommendations.
+
+## 8. Budget Optimization
+SLSQP optimizer with ±20% bounds on each channel. Objective: maximize expected revenue. Constraint: total budget = $2.4M/month.
+
+See `budget_20pct/optimization_summary.json` for detailed allocation.

--- a/viewer/fly.toml
+++ b/viewer/fly.toml
@@ -1,0 +1,16 @@
+app = "decision-lab-viewer"
+primary_region = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1,0 +1,840 @@
+{
+  "name": "decision-lab-viewer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "decision-lab-viewer",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.0",
+        "marked": "^12.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "decision-lab-viewer",
+  "version": "1.0.0",
+  "description": "Interactive session viewer for Decision Lab experiments",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "marked": "^12.0.0"
+  }
+}

--- a/viewer/public/index.html
+++ b/viewer/public/index.html
@@ -1,0 +1,1109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Decision Lab — Session Viewer</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --bg-secondary: #161b22;
+    --bg-tertiary: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-secondary: #8b949e;
+    --accent: #f97316;
+    --accent-dim: rgba(249, 115, 22, 0.15);
+    --green: #3fb950;
+    --green-dim: rgba(63, 185, 80, 0.15);
+    --blue: #58a6ff;
+    --blue-dim: rgba(88, 166, 255, 0.15);
+    --purple: #bc8cff;
+    --purple-dim: rgba(188, 140, 255, 0.15);
+    --red: #f85149;
+    --yellow: #d29922;
+    --node-size: 44px;
+    --sidebar-width: 320px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* Header */
+  .header {
+    height: 56px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    padding: 0 20px;
+    gap: 16px;
+  }
+  .header-logo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    font-size: 16px;
+  }
+  .header-logo svg { width: 28px; height: 28px; }
+  .header-badge {
+    background: var(--green-dim);
+    color: var(--green);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .header-info {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .header-info span { display: flex; align-items: center; gap: 4px; }
+
+  /* Main layout */
+  .main {
+    display: flex;
+    height: calc(100vh - 56px);
+  }
+
+  /* Sidebar */
+  .sidebar {
+    width: var(--sidebar-width);
+    min-width: var(--sidebar-width);
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .sidebar-header {
+    padding: 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+  }
+  .sidebar-content {
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  /* Workflow steps in sidebar */
+  .step-item {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 0.15s;
+    position: relative;
+  }
+  .step-item:hover { background: var(--bg-tertiary); }
+  .step-item.active { background: var(--accent-dim); border-left: 3px solid var(--accent); }
+  .step-item.active .step-label { color: var(--accent); }
+  .step-label {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .step-agent {
+    font-size: 11px;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .step-time {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+  }
+  .step-status {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+  }
+  .step-status.completed { background: var(--green); }
+  .step-status.running { background: var(--yellow); animation: pulse 1.5s infinite; }
+  .step-status.failed { background: var(--red); }
+  .step-metrics {
+    display: flex;
+    gap: 8px;
+    margin-top: 6px;
+  }
+  .step-metric {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+  }
+  .step-metric.good { background: var(--green-dim); color: var(--green); }
+  .step-metric.warn { background: rgba(210, 153, 34, 0.15); color: var(--yellow); }
+  .step-metric.selected-badge { background: var(--accent-dim); color: var(--accent); }
+  .parallel-indicator {
+    font-size: 10px;
+    color: var(--purple);
+    background: var(--purple-dim);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+
+  /* Center: Graph + Content */
+  .center {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Graph panel */
+  .graph-panel {
+    height: 260px;
+    min-height: 200px;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    position: relative;
+    overflow: auto;
+  }
+  .graph-panel svg {
+    display: block;
+  }
+
+  /* Graph nodes */
+  .graph-node {
+    cursor: pointer;
+    transition: filter 0.15s;
+  }
+  .graph-node:hover { filter: brightness(1.2); }
+  .graph-node.active rect,
+  .graph-node.active circle { stroke: var(--accent); stroke-width: 2.5; }
+
+  /* Content panel */
+  .content-panel {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px 32px;
+    background: var(--bg);
+  }
+  .content-title {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 4px;
+  }
+  .content-subtitle {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 20px;
+  }
+
+  /* Markdown rendering */
+  .markdown-body {
+    font-size: 14px;
+    line-height: 1.7;
+    color: var(--text);
+  }
+  .markdown-body h1 { font-size: 22px; font-weight: 700; margin: 24px 0 12px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+  .markdown-body h2 { font-size: 18px; font-weight: 600; margin: 20px 0 10px; color: var(--accent); }
+  .markdown-body h3 { font-size: 15px; font-weight: 600; margin: 16px 0 8px; }
+  .markdown-body p { margin: 8px 0; }
+  .markdown-body ul, .markdown-body ol { margin: 8px 0; padding-left: 24px; }
+  .markdown-body li { margin: 4px 0; }
+  .markdown-body code {
+    background: var(--bg-tertiary);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+  }
+  .markdown-body pre {
+    background: var(--bg-tertiary);
+    padding: 12px 16px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 12px 0;
+    border: 1px solid var(--border);
+  }
+  .markdown-body pre code { background: none; padding: 0; }
+  .markdown-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 12px 0;
+    font-size: 13px;
+  }
+  .markdown-body th, .markdown-body td {
+    border: 1px solid var(--border);
+    padding: 8px 12px;
+    text-align: left;
+  }
+  .markdown-body th {
+    background: var(--bg-tertiary);
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    color: var(--text-secondary);
+  }
+  .markdown-body strong { color: #fff; }
+  .markdown-body blockquote {
+    border-left: 3px solid var(--accent);
+    padding-left: 12px;
+    color: var(--text-secondary);
+    margin: 12px 0;
+  }
+
+  /* JSON viewer */
+  .json-viewer {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 12px;
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre-wrap;
+  }
+  .json-key { color: var(--blue); }
+  .json-string { color: var(--green); }
+  .json-number { color: var(--accent); }
+  .json-boolean { color: var(--purple); }
+  .json-null { color: var(--text-secondary); }
+
+  /* Metrics cards */
+  .metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin: 16px 0;
+  }
+  .metric-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px;
+  }
+  .metric-card-label {
+    font-size: 11px;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+  }
+  .metric-card-value {
+    font-size: 24px;
+    font-weight: 700;
+  }
+  .metric-card-value.good { color: var(--green); }
+  .metric-card-value.warn { color: var(--yellow); }
+  .metric-card-value.accent { color: var(--accent); }
+
+  /* ROAS bar chart */
+  .roas-chart {
+    margin: 16px 0;
+  }
+  .roas-bar-row {
+    display: flex;
+    align-items: center;
+    margin: 8px 0;
+    gap: 12px;
+  }
+  .roas-label {
+    width: 70px;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: right;
+    flex-shrink: 0;
+  }
+  .roas-bar-container {
+    flex: 1;
+    height: 28px;
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+  }
+  .roas-bar {
+    height: 100%;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    padding-left: 8px;
+    font-size: 12px;
+    font-weight: 600;
+    transition: width 0.6s ease;
+    position: relative;
+  }
+  .roas-bar .hdi-range {
+    position: absolute;
+    right: 8px;
+    font-size: 10px;
+    opacity: 0.7;
+  }
+  .roas-value {
+    width: 50px;
+    font-size: 13px;
+    font-weight: 700;
+    text-align: right;
+    flex-shrink: 0;
+  }
+
+  /* Saturation gauge */
+  .saturation-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+    margin: 16px 0;
+  }
+  .saturation-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px;
+    text-align: center;
+  }
+  .saturation-card-label { font-size: 12px; font-weight: 600; margin-bottom: 8px; }
+  .saturation-ring {
+    width: 80px;
+    height: 80px;
+    margin: 0 auto 8px;
+  }
+  .saturation-value { font-size: 18px; font-weight: 700; }
+
+  /* Tabs for artifact types */
+  .artifact-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 8px;
+  }
+  .artifact-tab {
+    padding: 6px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: all 0.15s;
+    background: none;
+    border: none;
+  }
+  .artifact-tab:hover { color: var(--text); background: var(--bg-tertiary); }
+  .artifact-tab.active { color: var(--accent); background: var(--accent-dim); }
+
+  /* Budget comparison */
+  .budget-table {
+    width: 100%;
+    margin: 12px 0;
+  }
+  .budget-change-positive { color: var(--green); }
+  .budget-change-negative { color: var(--red); }
+
+  /* Prompt box */
+  .prompt-box {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    margin: 12px 0;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text);
+    font-style: italic;
+  }
+
+  /* Scrollbar */
+  ::-webkit-scrollbar { width: 8px; height: 8px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--text-secondary); }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-logo">
+    <svg viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="28" height="28" rx="6" fill="#f97316"/>
+      <path d="M7 14L12 9L17 14L12 19Z" fill="white"/>
+      <path d="M14 10L19 5L24 10L19 15Z" fill="white" opacity="0.6"/>
+    </svg>
+    Decision Lab
+  </div>
+  <span class="header-badge" id="status-badge">Completed</span>
+  <div class="header-info">
+    <span id="dpack-name"></span>
+    <span id="session-duration"></span>
+    <span id="model-name"></span>
+  </div>
+</div>
+
+<div class="main">
+  <div class="sidebar">
+    <div class="sidebar-header">Workflow Steps</div>
+    <div class="sidebar-content" id="sidebar-steps"></div>
+  </div>
+  <div class="center">
+    <div class="graph-panel" id="graph-panel"></div>
+    <div class="content-panel" id="content-panel">
+      <div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-secondary);">
+        Select a workflow step to view details
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+// Minimal markdown parser (no external deps)
+const md = {
+  render(text) {
+    if (!text) return '';
+    let html = text
+      // Code blocks
+      .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code class="lang-$1">$2</code></pre>')
+      // Tables
+      .replace(/^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)*)/gm, (_, header, sep, body) => {
+        const ths = header.split('|').filter(c => c.trim()).map(c => `<th>${c.trim()}</th>`).join('');
+        const rows = body.trim().split('\n').map(row => {
+          const tds = row.split('|').filter(c => c.trim()).map(c => `<td>${c.trim()}</td>`).join('');
+          return `<tr>${tds}</tr>`;
+        }).join('');
+        return `<table><thead><tr>${ths}</tr></thead><tbody>${rows}</tbody></table>`;
+      })
+      // Headers
+      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+      .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+      // Bold + italic
+      .replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      // Inline code
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      // Unordered lists
+      .replace(/^- (.+)$/gm, '<li>$1</li>')
+      // Ordered lists
+      .replace(/^\d+\. (.+)$/gm, '<li>$1</li>')
+      // Paragraphs (simple: blank lines)
+      .replace(/\n\n/g, '</p><p>')
+      // Line breaks
+      .replace(/\n/g, '<br>');
+
+    // Wrap consecutive <li> in <ul>
+    html = html.replace(/(<li>.*?<\/li>(?:<br>)?)+/g, match => {
+      return '<ul>' + match.replace(/<br>/g, '') + '</ul>';
+    });
+
+    return '<p>' + html + '</p>';
+  }
+};
+
+let sessionData = null;
+let activeStepId = null;
+
+async function init() {
+  const res = await fetch('/api/session');
+  sessionData = await res.json();
+
+  renderHeader();
+  renderSidebar();
+  renderGraph();
+
+  // Select first step
+  selectStep('start');
+}
+
+function renderHeader() {
+  const s = sessionData;
+  document.getElementById('dpack-name').textContent = `Pack: ${s.dpack}`;
+  document.getElementById('model-name').textContent = s.model.split('/').pop();
+
+  const start = new Date(s.started_at);
+  const end = new Date(s.completed_at);
+  const mins = Math.round((end - start) / 60000);
+  document.getElementById('session-duration').textContent = `${mins} min`;
+}
+
+function renderSidebar() {
+  const container = document.getElementById('sidebar-steps');
+  container.innerHTML = '';
+
+  for (const step of sessionData.workflow) {
+    const el = document.createElement('div');
+    el.className = 'step-item';
+    el.dataset.id = step.id;
+
+    let metricsHtml = '';
+    if (step.metrics) {
+      const r2Class = step.metrics.r2 >= 0.9 ? 'good' : 'warn';
+      metricsHtml = `<div class="step-metrics">
+        <span class="step-metric ${r2Class}">R²=${step.metrics.r2}</span>
+        <span class="step-metric ${step.metrics.divergences === 0 ? 'good' : 'warn'}">div=${step.metrics.divergences}</span>
+        ${step.selected ? '<span class="step-metric selected-badge">SELECTED</span>' : ''}
+      </div>`;
+    }
+
+    let parallelHtml = '';
+    if (step.parallel_group) {
+      parallelHtml = `<span class="parallel-indicator">parallel</span>`;
+    }
+
+    const duration = step.started_at && step.completed_at
+      ? formatDuration(new Date(step.completed_at) - new Date(step.started_at))
+      : '';
+
+    el.innerHTML = `
+      <div class="step-label">
+        <span class="step-status ${step.status}"></span>
+        ${step.label}
+        ${parallelHtml}
+      </div>
+      <div class="step-agent">${step.agent}${step.instance ? ` #${step.instance}` : ''}</div>
+      ${duration ? `<div class="step-time">${duration}</div>` : ''}
+      ${metricsHtml}
+    `;
+
+    el.addEventListener('click', () => selectStep(step.id));
+    container.appendChild(el);
+  }
+}
+
+function formatDuration(ms) {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+// ---- Graph Rendering ----
+
+function renderGraph() {
+  const steps = sessionData.workflow;
+  const panel = document.getElementById('graph-panel');
+
+  // Layout: assign x,y positions
+  // Use a layered approach: each step gets a layer based on dependency depth
+  const layers = {};
+  const positions = {};
+  const nodeWidth = 160;
+  const nodeHeight = 48;
+  const layerGap = 100;
+  const nodeGap = 20;
+
+  // BFS to assign layers
+  const visited = new Set();
+  const queue = [{ id: 'start', layer: 0 }];
+  const stepMap = {};
+  steps.forEach(s => stepMap[s.id] = s);
+
+  while (queue.length > 0) {
+    const { id, layer } = queue.shift();
+    if (visited.has(id)) continue;
+    visited.add(id);
+
+    if (!layers[layer]) layers[layer] = [];
+    layers[layer].push(id);
+
+    const step = stepMap[id];
+    if (step && step.children) {
+      for (const child of step.children) {
+        queue.push({ id: child, layer: layer + 1 });
+      }
+    }
+  }
+
+  // Calculate positions
+  const maxNodesInLayer = Math.max(...Object.values(layers).map(l => l.length));
+  const svgWidth = Math.max((Object.keys(layers).length) * (nodeWidth + layerGap) + 80, 900);
+  const svgHeight = Math.max(maxNodesInLayer * (nodeHeight + nodeGap) + 60, 240);
+
+  for (const [layerIdx, nodeIds] of Object.entries(layers)) {
+    const x = 40 + parseInt(layerIdx) * (nodeWidth + layerGap);
+    const totalHeight = nodeIds.length * nodeHeight + (nodeIds.length - 1) * nodeGap;
+    const startY = (svgHeight - totalHeight) / 2;
+
+    nodeIds.forEach((id, i) => {
+      positions[id] = {
+        x,
+        y: startY + i * (nodeHeight + nodeGap),
+        w: nodeWidth,
+        h: nodeHeight
+      };
+    });
+  }
+
+  // Build SVG
+  let svg = `<svg width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}">`;
+
+  // Defs for arrow markers and gradients
+  svg += `<defs>
+    <marker id="arrow" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,3 L0,6" fill="#30363d"/>
+    </marker>
+    <linearGradient id="grad-green" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#238636"/>
+      <stop offset="100%" stop-color="#2ea043"/>
+    </linearGradient>
+    <linearGradient id="grad-orange" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#f97316"/>
+    </linearGradient>
+  </defs>`;
+
+  // Draw edges
+  for (const step of steps) {
+    if (!step.children) continue;
+    const from = positions[step.id];
+    if (!from) continue;
+
+    for (const childId of step.children) {
+      const to = positions[childId];
+      if (!to) continue;
+
+      const x1 = from.x + from.w;
+      const y1 = from.y + from.h / 2;
+      const x2 = to.x;
+      const y2 = to.y + to.h / 2;
+      const cx1 = x1 + (x2 - x1) * 0.4;
+      const cx2 = x2 - (x2 - x1) * 0.4;
+
+      svg += `<path d="M${x1},${y1} C${cx1},${y1} ${cx2},${y2} ${x2},${y2}"
+        fill="none" stroke="#30363d" stroke-width="2" marker-end="url(#arrow)"/>`;
+    }
+  }
+
+  // Draw nodes
+  for (const step of steps) {
+    const pos = positions[step.id];
+    if (!pos) continue;
+
+    const isSelected = step.selected;
+    const fill = isSelected ? 'var(--accent-dim)' : 'var(--bg-secondary)';
+    const stroke = isSelected ? 'var(--accent)' : 'var(--border)';
+    const strokeW = isSelected ? 2 : 1;
+
+    // Agent color coding
+    let agentColor = 'var(--text-secondary)';
+    if (step.agent === 'orchestrator') agentColor = 'var(--blue)';
+    if (step.agent === 'data-explorer') agentColor = 'var(--green)';
+    if (step.agent === 'data-preparer') agentColor = 'var(--purple)';
+    if (step.agent === 'modeler') agentColor = 'var(--accent)';
+
+    // Status dot
+    const statusColor = step.status === 'completed' ? 'var(--green)' :
+                        step.status === 'running' ? 'var(--yellow)' : 'var(--red)';
+
+    const label = step.label.length > 22 ? step.label.substring(0, 20) + '...' : step.label;
+
+    svg += `<g class="graph-node" data-id="${step.id}" onclick="selectStep('${step.id}')">
+      <rect x="${pos.x}" y="${pos.y}" width="${pos.w}" height="${pos.h}"
+        rx="8" fill="${fill}" stroke="${stroke}" stroke-width="${strokeW}"/>
+      <circle cx="${pos.x + 14}" cy="${pos.y + pos.h/2}" r="4" fill="${statusColor}"/>
+      <text x="${pos.x + 26}" y="${pos.y + pos.h/2 - 5}" fill="var(--text)"
+        font-size="11" font-weight="600" font-family="inherit">${label}</text>
+      <text x="${pos.x + 26}" y="${pos.y + pos.h/2 + 10}" fill="${agentColor}"
+        font-size="10" font-family="inherit">${step.agent}${step.instance ? ' #'+step.instance : ''}</text>
+    </g>`;
+  }
+
+  svg += '</svg>';
+  panel.innerHTML = svg;
+}
+
+// ---- Step Selection & Content ----
+
+function selectStep(stepId) {
+  activeStepId = stepId;
+
+  // Update sidebar
+  document.querySelectorAll('.step-item').forEach(el => {
+    el.classList.toggle('active', el.dataset.id === stepId);
+  });
+
+  // Update graph
+  document.querySelectorAll('.graph-node').forEach(el => {
+    el.classList.toggle('active', el.dataset.id === stepId);
+  });
+
+  // Load content
+  const step = sessionData.workflow.find(s => s.id === stepId);
+  renderStepContent(step);
+}
+
+async function renderStepContent(step) {
+  const panel = document.getElementById('content-panel');
+
+  if (step.id === 'start') {
+    panel.innerHTML = `
+      <div class="content-title">Session Start</div>
+      <div class="content-subtitle">MMM Analysis Session</div>
+      <h3 style="margin-top: 16px; font-size: 14px; color: var(--text-secondary);">User Prompt</h3>
+      <div class="prompt-box">${sessionData.prompt}</div>
+      <div class="metrics-grid">
+        <div class="metric-card">
+          <div class="metric-card-label">Decision Pack</div>
+          <div class="metric-card-value accent">${sessionData.dpack}</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card-label">Model</div>
+          <div class="metric-card-value" style="font-size: 14px;">${sessionData.model.split('/').pop()}</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card-label">Status</div>
+          <div class="metric-card-value good">${sessionData.status}</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card-label">Duration</div>
+          <div class="metric-card-value accent">${formatDuration(new Date(sessionData.completed_at) - new Date(sessionData.started_at))}</div>
+        </div>
+      </div>
+    `;
+    return;
+  }
+
+  // Check for model instances with metrics (show comparison view)
+  if (step.id === 'conflict') {
+    await renderConflictView(panel, step);
+    return;
+  }
+
+  if (step.id === 'optimize') {
+    await renderBudgetView(panel, step);
+    return;
+  }
+
+  // For model steps, show rich metrics
+  if (step.metrics) {
+    await renderModelView(panel, step);
+    return;
+  }
+
+  // Default: show artifacts
+  if (step.artifacts && step.artifacts.length > 0) {
+    let tabsHtml = '<div class="artifact-tabs">';
+    step.artifacts.forEach((a, i) => {
+      const name = a.split('/').pop();
+      tabsHtml += `<button class="artifact-tab ${i === 0 ? 'active' : ''}"
+        onclick="loadArtifact('${a}', this)">${name}</button>`;
+    });
+    tabsHtml += '</div>';
+
+    panel.innerHTML = `
+      <div class="content-title">${step.label}</div>
+      <div class="content-subtitle">${step.agent} — ${formatDuration(new Date(step.completed_at) - new Date(step.started_at))}</div>
+      ${tabsHtml}
+      <div id="artifact-content"><div style="color: var(--text-secondary);">Loading...</div></div>
+    `;
+
+    loadArtifact(step.artifacts[0]);
+  } else {
+    panel.innerHTML = `
+      <div class="content-title">${step.label}</div>
+      <div class="content-subtitle">${step.agent} — ${formatDuration(new Date(step.completed_at) - new Date(step.started_at))}</div>
+      <p style="color: var(--text-secondary); margin-top: 16px;">No artifacts produced by this step.</p>
+    `;
+  }
+}
+
+async function loadArtifact(path, tabEl) {
+  if (tabEl) {
+    tabEl.parentElement.querySelectorAll('.artifact-tab').forEach(t => t.classList.remove('active'));
+    tabEl.classList.add('active');
+  }
+
+  const container = document.getElementById('artifact-content');
+  if (!container) return;
+  container.innerHTML = '<div style="color: var(--text-secondary);">Loading...</div>';
+
+  try {
+    const ext = path.split('.').pop();
+    if (ext === 'json') {
+      const res = await fetch(`/api/artifact/${path}`);
+      const data = await res.json();
+      container.innerHTML = `<div class="json-viewer">${syntaxHighlight(JSON.stringify(data, null, 2))}</div>`;
+    } else {
+      const res = await fetch(`/api/artifact/${path}`);
+      const text = await res.text();
+      container.innerHTML = `<div class="markdown-body">${md.render(text)}</div>`;
+    }
+  } catch (e) {
+    container.innerHTML = `<div style="color: var(--red);">Error loading artifact: ${e.message}</div>`;
+  }
+}
+
+function syntaxHighlight(json) {
+  return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
+    function (match) {
+      let cls = 'json-number';
+      if (/^"/.test(match)) {
+        cls = /:$/.test(match) ? 'json-key' : 'json-string';
+      } else if (/true|false/.test(match)) {
+        cls = 'json-boolean';
+      } else if (/null/.test(match)) {
+        cls = 'json-null';
+      }
+      return `<span class="${cls}">${match}</span>`;
+    });
+}
+
+async function renderModelView(panel, step) {
+  const m = step.metrics;
+  const analysisPath = step.artifacts.find(a => a.endsWith('.json'));
+
+  let analysisData = null;
+  if (analysisPath) {
+    try {
+      const res = await fetch(`/api/artifact/${analysisPath}`);
+      analysisData = await res.json();
+    } catch (e) {}
+  }
+
+  const roas = analysisData?.roas || {};
+  const saturation = analysisData?.saturation || {};
+  const channels = Object.keys(roas);
+  const maxRoas = Math.max(...channels.map(c => roas[c]?.hdi_high || roas[c]?.mean || 0));
+
+  const channelColors = { tv: '#ef4444', digital: '#3b82f6', social: '#a855f7', search: '#22c55e', print: '#8b5cf6' };
+
+  let roasHtml = '';
+  for (const ch of channels) {
+    const r = roas[ch];
+    const pct = (r.mean / maxRoas * 100).toFixed(0);
+    const hdiPct = ((r.hdi_high - r.hdi_low) / maxRoas * 100).toFixed(0);
+    const color = channelColors[ch] || 'var(--accent)';
+    roasHtml += `<div class="roas-bar-row">
+      <div class="roas-label">${ch.charAt(0).toUpperCase() + ch.slice(1)}</div>
+      <div class="roas-bar-container">
+        <div class="roas-bar" style="width: ${pct}%; background: ${color}40; border-left: 3px solid ${color};">
+          <span class="hdi-range">[${r.hdi_low.toFixed(1)} – ${r.hdi_high.toFixed(1)}]</span>
+        </div>
+      </div>
+      <div class="roas-value" style="color: ${color};">${r.mean.toFixed(2)}x</div>
+    </div>`;
+  }
+
+  let satHtml = '';
+  for (const ch of channels) {
+    const sat = saturation[ch];
+    if (sat == null) continue;
+    const pct = (sat * 100).toFixed(0);
+    const color = sat > 0.75 ? 'var(--red)' : sat > 0.55 ? 'var(--yellow)' : 'var(--green)';
+    const circumference = 2 * Math.PI * 34;
+    const offset = circumference * (1 - sat);
+    satHtml += `<div class="saturation-card">
+      <div class="saturation-card-label">${ch.charAt(0).toUpperCase() + ch.slice(1)}</div>
+      <svg class="saturation-ring" viewBox="0 0 80 80">
+        <circle cx="40" cy="40" r="34" fill="none" stroke="var(--border)" stroke-width="6"/>
+        <circle cx="40" cy="40" r="34" fill="none" stroke="${color}" stroke-width="6"
+          stroke-dasharray="${circumference}" stroke-dashoffset="${offset}"
+          stroke-linecap="round" transform="rotate(-90 40 40)"/>
+        <text x="40" y="44" text-anchor="middle" fill="${color}" font-size="16" font-weight="700" font-family="inherit">${pct}%</text>
+      </svg>
+    </div>`;
+  }
+
+  panel.innerHTML = `
+    <div class="content-title">${step.label}${step.selected ? ' <span style="color: var(--accent); font-size: 14px;">★ SELECTED</span>' : ''}</div>
+    <div class="content-subtitle">${step.agent} #${step.instance} — ${formatDuration(step.duration_seconds * 1000)}</div>
+    <div class="metrics-grid">
+      <div class="metric-card">
+        <div class="metric-card-label">R² (in-sample)</div>
+        <div class="metric-card-value ${m.r2 >= 0.9 ? 'good' : 'warn'}">${m.r2}</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-card-label">MAPE</div>
+        <div class="metric-card-value ${m.mape <= 0.07 ? 'good' : 'warn'}">${(m.mape * 100).toFixed(1)}%</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-card-label">Divergences</div>
+        <div class="metric-card-value ${m.divergences === 0 ? 'good' : 'warn'}">${m.divergences}</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-card-label">Converged</div>
+        <div class="metric-card-value ${m.converged ? 'good' : 'warn'}">${m.converged ? 'Yes' : 'No'}</div>
+      </div>
+    </div>
+
+    <h2 style="font-size: 16px; margin-top: 24px; color: var(--accent);">Channel ROAS</h2>
+    <div class="roas-chart">${roasHtml}</div>
+
+    <h2 style="font-size: 16px; margin-top: 24px; color: var(--accent);">Saturation Levels</h2>
+    <div class="saturation-grid">${satHtml}</div>
+
+    ${step.artifacts.find(a => a.endsWith('.md')) ? `
+    <h2 style="font-size: 16px; margin-top: 24px; color: var(--accent);">Full Report</h2>
+    <div id="artifact-content"><div style="color: var(--text-secondary);">Loading...</div></div>
+    ` : ''}
+  `;
+
+  const mdArtifact = step.artifacts.find(a => a.endsWith('.md'));
+  if (mdArtifact) {
+    loadArtifact(mdArtifact);
+  }
+}
+
+async function renderConflictView(panel, step) {
+  // Load conflict detection markdown
+  const allModels = sessionData.workflow.filter(s => s.parallel_group === 'modeling');
+
+  let comparisonHtml = '<table class="markdown-body" style="font-size: 13px;"><thead><tr><th>Metric</th>';
+  allModels.forEach(m => {
+    comparisonHtml += `<th>${m.label}${m.selected ? ' ★' : ''}</th>`;
+  });
+  comparisonHtml += '</tr></thead><tbody>';
+
+  const metrics = [
+    { key: 'r2', label: 'R²', fmt: v => v.toFixed(2) },
+    { key: 'mape', label: 'MAPE', fmt: v => (v*100).toFixed(1)+'%' },
+    { key: 'divergences', label: 'Divergences', fmt: v => v },
+  ];
+  metrics.forEach(({ key, label, fmt }) => {
+    comparisonHtml += `<tr><td><strong>${label}</strong></td>`;
+    allModels.forEach(m => {
+      const val = m.metrics[key];
+      comparisonHtml += `<td>${fmt(val)}</td>`;
+    });
+    comparisonHtml += '</tr>';
+  });
+  comparisonHtml += '</tbody></table>';
+
+  panel.innerHTML = `
+    <div class="content-title">${step.label}</div>
+    <div class="content-subtitle">Result: <strong style="color: var(--green);">No Conflicts Detected</strong></div>
+
+    <h2 style="font-size: 16px; margin-top: 20px; color: var(--accent);">Model Comparison</h2>
+    ${comparisonHtml}
+
+    <div class="artifact-tabs" style="margin-top: 20px;">
+      ${step.artifacts.map((a, i) => `<button class="artifact-tab ${i === 0 ? 'active' : ''}"
+        onclick="loadArtifact('${a}', this)">${a.split('/').pop()}</button>`).join('')}
+    </div>
+    <div id="artifact-content"><div style="color: var(--text-secondary);">Loading...</div></div>
+  `;
+
+  if (step.artifacts.length > 0) {
+    loadArtifact(step.artifacts[0]);
+  }
+}
+
+async function renderBudgetView(panel, step) {
+  let budgetData = null;
+  const jsonPath = step.artifacts.find(a => a.endsWith('.json'));
+  if (jsonPath) {
+    try {
+      const res = await fetch(`/api/artifact/${jsonPath}`);
+      budgetData = await res.json();
+    } catch (e) {}
+  }
+
+  if (!budgetData) {
+    panel.innerHTML = `<div class="content-title">${step.label}</div><p>No data available.</p>`;
+    return;
+  }
+
+  const alloc = budgetData.allocation;
+  const channels = Object.keys(alloc);
+
+  let tableHtml = '<table class="markdown-body" style="font-size: 13px;"><thead><tr><th>Channel</th><th>Current</th><th>Optimized</th><th>Change</th></tr></thead><tbody>';
+  channels.forEach(ch => {
+    const a = alloc[ch];
+    const changeClass = a.change_pct > 0 ? 'budget-change-positive' : 'budget-change-negative';
+    const changeSign = a.change_pct > 0 ? '+' : '';
+    tableHtml += `<tr>
+      <td><strong>${ch.charAt(0).toUpperCase() + ch.slice(1)}</strong></td>
+      <td>$${(a.current/1000).toFixed(0)}K</td>
+      <td>$${(a.optimized/1000).toFixed(0)}K</td>
+      <td class="${changeClass}">${changeSign}${a.change_pct.toFixed(0)}%</td>
+    </tr>`;
+  });
+  tableHtml += '</tbody></table>';
+
+  // Build bar comparison
+  const maxSpend = Math.max(...channels.map(c => Math.max(alloc[c].current, alloc[c].optimized)));
+  let barsHtml = '';
+  const channelColors = { tv: '#ef4444', digital: '#3b82f6', social: '#a855f7', search: '#22c55e', print: '#8b5cf6' };
+  channels.forEach(ch => {
+    const a = alloc[ch];
+    const curPct = (a.current / maxSpend * 100).toFixed(0);
+    const optPct = (a.optimized / maxSpend * 100).toFixed(0);
+    const color = channelColors[ch] || 'var(--accent)';
+    barsHtml += `<div style="margin: 12px 0;">
+      <div style="font-size: 12px; font-weight: 600; margin-bottom: 4px;">${ch.charAt(0).toUpperCase() + ch.slice(1)}</div>
+      <div style="display: flex; gap: 4px; align-items: center;">
+        <div style="width: 60px; font-size: 11px; color: var(--text-secondary);">Current</div>
+        <div style="flex: 1; height: 16px; background: var(--bg-tertiary); border-radius: 3px; overflow: hidden;">
+          <div style="width: ${curPct}%; height: 100%; background: ${color}40; border-radius: 3px;"></div>
+        </div>
+        <div style="width: 60px; font-size: 11px; text-align: right;">$${(a.current/1000).toFixed(0)}K</div>
+      </div>
+      <div style="display: flex; gap: 4px; align-items: center; margin-top: 2px;">
+        <div style="width: 60px; font-size: 11px; color: var(--accent);">Optimal</div>
+        <div style="flex: 1; height: 16px; background: var(--bg-tertiary); border-radius: 3px; overflow: hidden;">
+          <div style="width: ${optPct}%; height: 100%; background: ${color}; border-radius: 3px;"></div>
+        </div>
+        <div style="width: 60px; font-size: 11px; text-align: right; color: var(--accent);">$${(a.optimized/1000).toFixed(0)}K</div>
+      </div>
+    </div>`;
+  });
+
+  panel.innerHTML = `
+    <div class="content-title">${step.label}</div>
+    <div class="content-subtitle">Risk level: ±${budgetData.risk_level} bounds</div>
+    <div class="metrics-grid">
+      <div class="metric-card">
+        <div class="metric-card-label">Total Budget</div>
+        <div class="metric-card-value accent">$${(budgetData.total_budget/1e6).toFixed(1)}M</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-card-label">Expected Uplift</div>
+        <div class="metric-card-value good">+${budgetData.expected_uplift_pct}%</div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-card-label">Additional Revenue</div>
+        <div class="metric-card-value good">+$${(budgetData.expected_additional_revenue/1000).toFixed(0)}K/mo</div>
+      </div>
+    </div>
+
+    <h2 style="font-size: 16px; margin-top: 24px; color: var(--accent);">Budget Allocation</h2>
+    ${barsHtml}
+
+    <h2 style="font-size: 16px; margin-top: 24px; color: var(--accent);">Allocation Table</h2>
+    ${tableHtml}
+
+    <h2 style="font-size: 16px; margin-top: 24px; color: var(--accent);">Key Moves</h2>
+    <ul style="font-size: 13px; line-height: 1.8; padding-left: 20px;">
+      ${budgetData.key_moves.map(m => `<li>${m}</li>`).join('')}
+    </ul>
+  `;
+}
+
+// Init
+init();
+</script>
+</body>
+</html>

--- a/viewer/server.js
+++ b/viewer/server.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const PORT = process.env.PORT || 8080;
+const SESSION_DIR = path.join(__dirname, 'demo-session');
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+// API: Get session manifest
+app.get('/api/session', (req, res) => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(SESSION_DIR, 'session_manifest.json'), 'utf-8'));
+  res.json(manifest);
+});
+
+// API: Get artifact content
+app.get('/api/artifact/*', (req, res) => {
+  const artifactPath = req.params[0];
+  const fullPath = path.join(SESSION_DIR, artifactPath);
+
+  // Prevent path traversal
+  if (!fullPath.startsWith(SESSION_DIR)) {
+    return res.status(403).json({ error: 'Access denied' });
+  }
+
+  if (!fs.existsSync(fullPath)) {
+    return res.status(404).json({ error: 'Artifact not found' });
+  }
+
+  const content = fs.readFileSync(fullPath, 'utf-8');
+  const ext = path.extname(artifactPath);
+
+  if (ext === '.json') {
+    res.json(JSON.parse(content));
+  } else {
+    res.type('text/plain').send(content);
+  }
+});
+
+// API: List all artifacts in session
+app.get('/api/artifacts', (req, res) => {
+  const artifacts = [];
+
+  function walk(dir, prefix = '') {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (!entry.name.startsWith('.') && entry.name !== 'data') {
+          walk(path.join(dir, entry.name), relPath);
+        }
+      } else if (!entry.name.startsWith('.')) {
+        const ext = path.extname(entry.name);
+        artifacts.push({
+          path: relPath,
+          name: entry.name,
+          type: ext === '.json' ? 'json' : ext === '.md' ? 'markdown' : ext === '.csv' ? 'csv' : 'text',
+          size: fs.statSync(path.join(dir, entry.name)).size
+        });
+      }
+    }
+  }
+
+  walk(SESSION_DIR);
+  res.json(artifacts);
+});
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`Decision Lab Viewer running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary

- Adds an interactive web UI for viewing Decision Lab experiment sessions as directed graphs, ported from [decision-agent-lite PR #1](https://github.com/pymc-labs/decision-agent-lite/pull/1)
- Includes an Express server (`viewer/server.js`) that serves session data and a single-page app (`viewer/public/index.html`) for visualizing experiment workflows
- Ships with a demo session containing sample analysis instances, reports, and optimization results
- Includes Fly.io deployment configuration (`fly.toml` + `Dockerfile`) for hosting

## Test plan

- [ ] Run `cd viewer && npm install && npm start` and verify the viewer loads at `http://localhost:8080`
- [ ] Confirm the demo session renders as a directed graph with expandable node details
- [ ] Verify the Dockerfile builds successfully: `cd viewer && docker build -t viewer .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)