### PR TITLE
README v6: PR #11 + convergence framing + visual placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ Coding agents write good code. They make bad analytical decisions.
 
 Ask a coding agent to analyze your marketing data and it will fit a model, generate charts, and recommend budget reallocations — all in clean code. The problem is the model might be wrong, the assumptions unchecked, and the recommendations unsupported. Nobody notices for months.
 
-decision-lab runs multiple modeling approaches in parallel, checks whether they agree, and only recommends when results hold up across different assumptions. When they don't, it tells you what it doesn't know and what experiments would resolve the uncertainty.
+decision-lab runs multiple modeling approaches in parallel, checks whether they converge, and only reports conclusions that survive across different assumptions. When they don't converge, it tells you what it doesn't know and what experiments would resolve the uncertainty.
 
+<!-- TODO: Architecture diagram — orchestrator → parallel subagents → consolidator.
+     Show: (1) single prompt + dataset enter the orchestrator,
+     (2) fan-out to N parallel subagents, each with a different modeling approach,
+     (3) consolidator compares results, produces one report with convergence/divergence assessment.
+     Three stages, left to right. Keep it minimal. -->
 
 ## Why
 
@@ -17,11 +22,11 @@ That's the behavior we want: an agent that knows when to stop.
 
 ## How it works
 
-You package everything an agent needs into a **decision-pack**: a frozen Docker environment, agent prompts, domain skills, and tools. The agent explores multiple approaches instead of committing to the first one that runs, and consolidates the results into a report.
+You package everything an agent needs into a **decision-pack**: a frozen Docker environment, agent prompts, domain skills, and tools. The agent explores multiple approaches instead of committing to the first one that runs. A consolidator compares results across approaches and produces a single report with a convergence assessment.
 
 **Skills** constrain the agent to methodologically sound paths — mandatory diagnostics, preferred model structures, informative priors.
 
-**Parallel subagents** fan out with different approaches to the same problem (different priors, different data prep, different model structures). If they converge, you can trust the result. If they diverge, the agent flags the disagreement. Supports running compute-heavy tasks on [Modal](https://modal.com).
+**Parallel subagents** fan out with different approaches to the same problem (different priors, different data prep, different model structures). If results converge across approaches, you have evidence the conclusions are robust. If they diverge, the consolidator flags the disagreement and identifies what drives it. Supports running compute-heavy tasks on [Modal](https://modal.com).
 
 **Frozen environments** pin the Docker image so the agent codes against the right library versions. No "works on my laptop."
 


### PR DESCRIPTION
## Summary

Based on Ben's PR #11 (factually accurate, lean). Three targeted additions:

- **Convergence language** in intro and "How it works" — the multiple-paths/convergence framing scored highest on clarity across all synthetic panel variants (14/15 scored 4+ on clarity). Changed "checks whether they agree" → "checks whether they converge" and made the consolidator step explicit.
- **Architecture diagram placeholder** — HTML comment with a detailed description of what the visual should show (orchestrator → parallel subagents → consolidator, three stages left to right). No image yet, just the spec.
- **Consolidator made explicit** — PR #11 mentioned consolidation implicitly. This version names the consolidator as a distinct step that "compares results across approaches and produces a single report with a convergence assessment." This matches what the code actually does (see `modeler.yaml` and the consolidator auto-generation).

Everything else is unchanged from PR #11. No bloat, no hype, no fabricated output snippets.

## What this does NOT change
- The opener ("Coding agents write good code...") — highest-scoring line, kept verbatim
- The "Why" section — factual, links to video, kept as-is
- Skills / Parallel subagents / Frozen environments structure — Ben's framing, kept
- Install, Quick start, decision-pack structure, Features, CLI reference, Docs — all unchanged

## Test plan
- [ ] Review diff against PR #11 — should be 3 small edits
- [ ] Verify convergence/consolidator language matches actual codebase behavior
- [ ] Visual placeholder is HTML comment only, invisible in rendered markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)