### PR TITLE
TUI: polish agent selection, navigation, and artifact display

### DIFF
--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -134,6 +134,7 @@ class ConnectApp(App):
         padding: 0 1;
     }
 
+
     ArtifactList {
         height: 1fr;
         padding: 0 1;
@@ -264,6 +265,12 @@ class ConnectApp(App):
         # Show placeholder in file viewer
         file_viewer = self.query_one("#file-viewer", FileViewer)
         file_viewer.show_placeholder()
+
+        # Focus log view and select last event
+        log_view = self.query_one("#log-view", LogView)
+        log_view.focus()
+        if log_view._widgets:
+            log_view.selected_index = len(log_view._widgets) - 1
 
         # Start periodic update timer
         self._update_timer = self.set_interval(0.5, self._on_update_tick)

--- a/dlab/tui/models.py
+++ b/dlab/tui/models.py
@@ -44,6 +44,7 @@ class LogEvent:
     raw: dict[str, Any]
     cost: float = 0.0
     duration_ms: int | None = None
+    hidden: bool = False    # True for step_start/step_finish (not rendered)
 
     @property
     def full_description(self) -> str:
@@ -199,6 +200,7 @@ class LogEvent:
         description = ""
         cost = 0.0
         duration_ms = None
+        hidden = False
 
         if event_type == "dlab_start":
             model = raw.get("model", part.get("model", "unknown"))
@@ -215,11 +217,12 @@ class LogEvent:
             description = part.get("text", "")
 
         elif event_type == "step_start":
-            description = "Step started"
+            description = ""
+            hidden = True
 
         elif event_type == "step_finish":
-            reason = part.get("reason", "unknown")
-            description = f"Step finished ({reason})"
+            description = ""
+            hidden = True
             cost = part.get("cost", 0.0)
 
         elif event_type == "text":
@@ -316,6 +319,7 @@ class LogEvent:
             raw=raw,
             cost=cost,
             duration_ms=duration_ms,
+            hidden=hidden,
         )
 
 

--- a/dlab/tui/widgets/agent_list.py
+++ b/dlab/tui/widgets/agent_list.py
@@ -72,16 +72,24 @@ class AgentListItem(ListItem):
 
     def compose(self):
         """Compose the widget."""
+        self._display_name = shorten_agent_name(self.agent_name)
+        yield Static(self._build_text(False), id="agent-label")
+
+    def _build_text(self, highlighted: bool) -> Text:
         if self.agent_running:
             indicator = Text("● ", style="bold #A6E22E")
+            name_style = "black" if highlighted else ""
         else:
             indicator = Text("○ ", style="#75715E")
+            name_style = "black" if highlighted else "#75715E"
+        return indicator + Text(self._display_name, style=name_style)
 
-        name_style = "" if self.agent_running else "#75715E"
-        display_name = shorten_agent_name(self.agent_name)
-        name_text = Text(display_name, style=name_style)
-
-        yield Static(indicator + name_text)
+    def watch_highlighted(self, value: bool) -> None:
+        super().watch_highlighted(value)
+        try:
+            self.query_one("#agent-label", Static).update(self._build_text(value))
+        except Exception:
+            pass
 
 
 class AgentSelector(ListView):

--- a/dlab/tui/widgets/artifacts_pane.py
+++ b/dlab/tui/widgets/artifacts_pane.py
@@ -182,8 +182,7 @@ class ArtifactItem(ListItem):
         else:
             display_path = self.file_path.name
 
-        # Sidebar is 28 wide - 2 padding = 26 cells. Tag is 3 chars + space = 4.
-        max_len: int = 22
+        max_len: int = 19
         if len(display_path) > max_len:
             display_path = display_path[:max_len - 1] + "…"
 
@@ -191,6 +190,21 @@ class ArtifactItem(ListItem):
         text.append(f"{tag:>3}", style="dim")
         text.append(f" {display_path}")
         yield Static(text)
+
+
+_ARTIFACT_TYPE_ORDER: dict[str, int] = {
+    ".md": 0, ".py": 1,
+    ".png": 2, ".jpg": 2, ".jpeg": 2,
+    ".csv": 3,
+}
+
+
+def _sort_artifacts(artifacts: list[Path]) -> list[Path]:
+    """Sort artifacts by type (md, py, img, csv, rest) then name."""
+    return sorted(
+        artifacts,
+        key=lambda p: (_ARTIFACT_TYPE_ORDER.get(p.suffix.lower(), 99), p.name.lower()),
+    )
 
 
 class ArtifactList(ListView):
@@ -234,6 +248,8 @@ class ArtifactList(ListView):
             self.append(ListItem(Static(Text("No files", style="dim italic"))))
             return
 
+        self._artifacts = _sort_artifacts(self._artifacts)
+
         for path in self._artifacts:
             self.append(ArtifactItem(path))
 
@@ -244,7 +260,7 @@ class ArtifactList(ListView):
 
         self._agent_dir = get_agent_directory(self._work_dir, self._agent_name)
         is_main = self._agent_name.startswith("main")
-        new_artifacts = discover_artifacts(self._work_dir, self._agent_dir, is_main=is_main)
+        new_artifacts = _sort_artifacts(discover_artifacts(self._work_dir, self._agent_dir, is_main=is_main))
 
         if new_artifacts != self._artifacts:
             self._artifacts = new_artifacts

--- a/dlab/tui/widgets/artifacts_pane.py
+++ b/dlab/tui/widgets/artifacts_pane.py
@@ -276,6 +276,11 @@ class ArtifactList(ListView):
         base = self._agent_dir if self._agent_dir else self._work_dir
         return base / rel_path
 
+    def on_focus(self) -> None:
+        """Auto-highlight first item when focused."""
+        if self.index is None and self.children:
+            self.index = 0
+
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Handle selection (Enter key)."""
         if isinstance(event.item, ArtifactItem):

--- a/dlab/tui/widgets/log_view.py
+++ b/dlab/tui/widgets/log_view.py
@@ -371,6 +371,7 @@ class LogView(VerticalScroll, can_focus=True):
         self._widgets: list[LogEventWidget] = []
         self._expand_all_mode: bool = False
         self._suppress_scroll: bool = False
+        self._arrow_navigating: bool = False
 
     def watch_selected_index(self, old_index: int, new_index: int) -> None:
         """Update selection visuals when index changes."""
@@ -447,7 +448,11 @@ class LogView(VerticalScroll, can_focus=True):
             self.scroll_end(animate=False)
 
     def _snap_selection_to_visible(self) -> None:
-        """If selected widget is off-screen, move selection to first visible."""
+        """If selected widget is off-screen, move selection to first visible.
+
+        When called from arrow keys (_arrow_navigating=True), just scrolls
+        to the current selection instead of snapping to a new one.
+        """
         if not self._widgets:
             return
         if 0 <= self.selected_index < len(self._widgets):
@@ -456,10 +461,22 @@ class LogView(VerticalScroll, can_focus=True):
             vp_bottom: int = vp_top + self.size.height
             try:
                 if w.virtual_region.y < vp_bottom and w.virtual_region.y + w.virtual_region.height > vp_top:
-                    return
+                    return  # Already visible
             except Exception:
                 return
-        # Snap — suppress scroll so we don't jump
+            # Off-screen: if arrow-navigating and just barely off edge, scroll to it
+            if self._arrow_navigating:
+                try:
+                    wy: int = w.virtual_region.y
+                    distance: int = min(abs(wy - vp_bottom), abs(wy - vp_top))
+                    # If within 3 line heights of viewport, just scroll (edge case)
+                    if distance < self.size.height // 2:
+                        self._widgets[self.selected_index].scroll_visible()
+                        return
+                except Exception:
+                    pass
+                # Far away — fall through to snap
+        # Snap to first visible — suppress scroll so we don't jump
         vp_top = self.scroll_offset.y
         self._suppress_scroll = True
         for i, widget in enumerate(self._widgets):
@@ -538,7 +555,9 @@ class LogView(VerticalScroll, can_focus=True):
         """Select the next event."""
         if not self._widgets:
             return
+        self._arrow_navigating = True
         self._snap_selection_to_visible()
+        self._arrow_navigating = False
         if self.selected_index < len(self._widgets) - 1:
             self.selected_index += 1
         elif self.selected_index == -1:
@@ -548,7 +567,9 @@ class LogView(VerticalScroll, can_focus=True):
         """Select the previous event."""
         if not self._widgets:
             return
+        self._arrow_navigating = True
         self._snap_selection_to_visible()
+        self._arrow_navigating = False
         if self.selected_index > 0:
             self.selected_index -= 1
         elif self.selected_index == -1:

--- a/dlab/tui/widgets/log_view.py
+++ b/dlab/tui/widgets/log_view.py
@@ -331,6 +331,15 @@ class LogEventWidget(Horizontal):
         if self._is_long:
             self.is_collapsed = not self.is_collapsed
 
+    def on_click(self) -> None:
+        """Select this event when clicked."""
+        try:
+            log_view: LogView = self.screen.query_one("#log-view", LogView)
+            idx: int = log_view._widgets.index(self)
+            log_view.selected_index = idx
+        except Exception:
+            pass
+
 
 class LogView(VerticalScroll, can_focus=True):
     """
@@ -361,6 +370,7 @@ class LogView(VerticalScroll, can_focus=True):
         self._global_start_ts: int | None = None
         self._widgets: list[LogEventWidget] = []
         self._expand_all_mode: bool = False
+        self._suppress_scroll: bool = False
 
     def watch_selected_index(self, old_index: int, new_index: int) -> None:
         """Update selection visuals when index changes."""
@@ -368,7 +378,8 @@ class LogView(VerticalScroll, can_focus=True):
             self._widgets[old_index].is_selected = False
         if 0 <= new_index < len(self._widgets):
             self._widgets[new_index].is_selected = True
-            self._widgets[new_index].scroll_visible()
+            if not self._suppress_scroll:
+                self._widgets[new_index].scroll_visible()
 
     def on_focus(self) -> None:
         """Auto-select first event when focusing if none selected."""
@@ -435,23 +446,54 @@ class LogView(VerticalScroll, can_focus=True):
         if self.auto_scroll:
             self.scroll_end(animate=False)
 
+    def _snap_selection_to_visible(self) -> None:
+        """If selected widget is off-screen, move selection to first visible."""
+        if not self._widgets:
+            return
+        if 0 <= self.selected_index < len(self._widgets):
+            w = self._widgets[self.selected_index]
+            vp_top: int = self.scroll_offset.y
+            vp_bottom: int = vp_top + self.size.height
+            try:
+                if w.virtual_region.y < vp_bottom and w.virtual_region.y + w.virtual_region.height > vp_top:
+                    return
+            except Exception:
+                return
+        # Snap — suppress scroll so we don't jump
+        vp_top = self.scroll_offset.y
+        self._suppress_scroll = True
+        for i, widget in enumerate(self._widgets):
+            try:
+                if widget.virtual_region.y + widget.virtual_region.height > vp_top:
+                    self.selected_index = i
+                    break
+            except Exception:
+                pass
+        self._suppress_scroll = False
+
     def expand_all(self) -> None:
         """Expand all collapsible events."""
+        self._snap_selection_to_visible()
         self._expand_all_mode = True
         for widget in self._widgets:
             widget.is_collapsed = False
         self.refresh(layout=True)
         if 0 <= self.selected_index < len(self._widgets):
-            self._widgets[self.selected_index].scroll_visible()
+            self.call_after_refresh(
+                self._widgets[self.selected_index].scroll_visible
+            )
 
     def collapse_all(self) -> None:
         """Collapse all collapsible events."""
+        self._snap_selection_to_visible()
         self._expand_all_mode = False
         for widget in self._widgets:
             widget.is_collapsed = True
         self.refresh(layout=True)
         if 0 <= self.selected_index < len(self._widgets):
-            self._widgets[self.selected_index].scroll_visible()
+            self.call_after_refresh(
+                self._widgets[self.selected_index].scroll_visible
+            )
 
     def highlight_search(self, query: str) -> list[int]:
         """
@@ -496,6 +538,7 @@ class LogView(VerticalScroll, can_focus=True):
         """Select the next event."""
         if not self._widgets:
             return
+        self._snap_selection_to_visible()
         if self.selected_index < len(self._widgets) - 1:
             self.selected_index += 1
         elif self.selected_index == -1:
@@ -505,6 +548,7 @@ class LogView(VerticalScroll, can_focus=True):
         """Select the previous event."""
         if not self._widgets:
             return
+        self._snap_selection_to_visible()
         if self.selected_index > 0:
             self.selected_index -= 1
         elif self.selected_index == -1:

--- a/dlab/tui/widgets/log_view.py
+++ b/dlab/tui/widgets/log_view.py
@@ -60,11 +60,19 @@ def format_relative_time(event_ts: int, global_start_ts: int | None) -> str:
     # Events with timestamp=0 have no time (additional_output events)
     # All returns must be exactly 10 chars for column alignment
     if event_ts == 0:
-        return "       ---"  # 10 chars
+        return "  ---"
     if global_start_ts is None:
-        return "   ????.?s"  # 10 chars
-    rel_seconds = (event_ts - global_start_ts) / 1000
-    return f"+{rel_seconds:8.1f}s"  # 10 chars
+        return "  ---"
+    rel_seconds: int = max(0, (event_ts - global_start_ts) // 1000)
+    if rel_seconds < 60:
+        return f"{rel_seconds:>3d}s"
+    minutes: int = rel_seconds // 60
+    s: int = rel_seconds % 60
+    if minutes < 60:
+        return f"{minutes}m{s:02d}s"
+    hours: int = minutes // 60
+    m: int = minutes % 60
+    return f"{hours}h{m:02d}m{s:02d}s"
 
 
 def format_duration(ms: int | None) -> str:
@@ -90,14 +98,27 @@ def format_duration(ms: int | None) -> str:
     return f"[{minutes:.1f}m]"
 
 
+# Display labels for event types (shorter, cleaner)
+_EVENT_TYPE_LABELS: dict[str, str] = {
+    "tool_use": "tool",
+    "raw_text": "raw",
+    "text": "",
+    "error": "err",
+    "dlab_start": "init",
+    "additional_output": "raw",
+    "step_start": "",
+    "step_finish": "",
+}
+
+
 class LogEventPrefix(Static):
     """Fixed-width prefix showing selection, time, and event type."""
 
     DEFAULT_CSS = """
     LogEventPrefix {
-        width: 27;
-        min-width: 27;
-        max-width: 27;
+        width: 17;
+        min-width: 17;
+        max-width: 17;
     }
     """
 
@@ -126,10 +147,10 @@ class LogEventPrefix(Static):
         else:
             text = Text("  ")
 
-        text.append(self._time_str, style="dim")
-        text.append("  ", style="dim")
-        text.append(f"{self._event_type:12}", style=self._style)
+        text.append(f"{self._time_str:>8}", style="dim")
         text.append(" ", style="dim")
+        label: str = _EVENT_TYPE_LABELS.get(self._event_type, self._event_type)
+        text.append(f"{label:<5}", style=self._style)
 
         return text
 
@@ -377,12 +398,12 @@ class LogView(VerticalScroll, can_focus=True):
 
     def _rebuild_widgets(self) -> None:
         """Rebuild all event widgets."""
-        # Clear existing
         self.remove_children()
         self._widgets = []
 
-        # Create new widgets
         for event in self._events:
+            if event.hidden:
+                continue
             widget = LogEventWidget(event, self._global_start_ts)
             self._widgets.append(widget)
             self.mount(widget)
@@ -400,6 +421,9 @@ class LogView(VerticalScroll, can_focus=True):
             Event to append.
         """
         self._events.append(event)
+        if event.hidden:
+            return
+
         widget = LogEventWidget(
             event,
             self._global_start_ts,


### PR DESCRIPTION
## Summary
- Auto-select first agent and focus log view on startup for better initial UX
- Fix arrow key navigation at viewport edges with snapping on expand/collapse
- Sort artifacts by type (md → py → images → csv), truncate long filenames
- Compact timestamps, rename event labels, hide step_start/step_finish events
- Improve agent highlight colors and auto-select first file in artifact list

## Commits
- `64caee4` TUI polish: hide step events, rename labels, compact timestamps
- `9d53487` TUI: snap selection to visible on expand/collapse and arrow keys
- `bede11f` TUI: fix arrow key navigation at viewport edge
- `c03f2e8` TUI: truncate long filenames, sort artifacts by type
- `671f329` TUI: agent highlight colors, auto-select first file, focus log on start

## Test plan
- [ ] Run `dlab connect <work-dir>` on an existing session and verify log view loads focused
- [ ] Navigate agents with j/k, verify first file auto-selected in artifact pane
- [ ] Expand/collapse events (e/c), verify selection snaps to visible range
- [ ] Arrow key through log events at top/bottom viewport edges
- [ ] Check long filenames are truncated with ellipsis in artifact list

🤖 Generated with [Claude Code](https://claude.com/claude-code)