### PR TITLE
Add peer review decision pack

### DIFF
--- a/decision-packs/peer-review/config.yaml
+++ b/decision-packs/peer-review/config.yaml
@@ -1,0 +1,5 @@
+name: peer-review
+description: Simulated academic peer review using parallel structural reviewers
+docker_image_name: dlab-peer-review
+default_model: anthropic/claude-opus-4-5
+requires_prompt: false

--- a/decision-packs/peer-review/docker/Dockerfile
+++ b/decision-packs/peer-review/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir \
+    PyMuPDF==1.25.3 \
+    pdfplumber==0.11.4 \
+    httpx==0.28.1
+
+COPY peer_review_lib /opt/peer_review_lib
+
+ENV PYTHONPATH="/opt"
+
+RUN python -c "import peer_review_lib; print('peer_review_lib import OK')"
+RUN python -c "import fitz; print('PyMuPDF import OK')"
+
+CMD ["/bin/bash"]

--- a/decision-packs/peer-review/docker/peer_review_lib/__init__.py
+++ b/decision-packs/peer-review/docker/peer_review_lib/__init__.py
@@ -1,0 +1,20 @@
+"""
+Peer Review Library
+
+Modules:
+- parse_paper: PDF/LaTeX → structured text with section boundaries
+- fetch_references: Semantic Scholar API client for building reference KB
+"""
+
+__version__ = "0.1.0"
+
+from .parse_paper import parse_paper, parse_and_print
+from .fetch_references import fetch_reference, fetch_references_batch
+
+__all__ = [
+    "__version__",
+    "parse_paper",
+    "parse_and_print",
+    "fetch_reference",
+    "fetch_references_batch",
+]

--- a/decision-packs/peer-review/docker/peer_review_lib/fetch_references.py
+++ b/decision-packs/peer-review/docker/peer_review_lib/fetch_references.py
@@ -1,0 +1,118 @@
+"""
+Semantic Scholar API client for fetching paper metadata and abstracts.
+
+Uses the Semantic Scholar Academic Graph API (free, no auth for basic usage).
+Rate limit: 100 requests per 5 minutes for unauthenticated access.
+"""
+
+import json
+import time
+from typing import Any
+
+import httpx
+
+
+BASE_URL = "https://api.semanticscholar.org/graph/v1"
+FIELDS = "title,authors,year,venue,abstract,citationCount,externalIds"
+REQUEST_INTERVAL = 3.0
+
+
+def fetch_reference(query: str, client: httpx.Client | None = None) -> dict[str, Any]:
+    """
+    Search Semantic Scholar for a paper by title or citation key.
+
+    Parameters
+    ----------
+    query : str
+        Paper title or citation key to search for.
+    client : httpx.Client | None
+        Optional reusable HTTP client. Creates one if not provided.
+
+    Returns
+    -------
+    dict[str, Any]
+        Paper metadata with keys: title, authors, year, venue, abstract,
+        citation_count, semantic_scholar_id, found.
+        If not found, returns dict with found=False and the query.
+    """
+    own_client = client is None
+    if own_client:
+        client = httpx.Client(timeout=15.0)
+
+    try:
+        resp = client.get(
+            f"{BASE_URL}/paper/search",
+            params={"query": query, "limit": 1, "fields": FIELDS},
+        )
+
+        if resp.status_code == 429:
+            time.sleep(10)
+            resp = client.get(
+                f"{BASE_URL}/paper/search",
+                params={"query": query, "limit": 1, "fields": FIELDS},
+            )
+
+        if resp.status_code != 200:
+            return {"found": False, "query": query, "error": f"HTTP {resp.status_code}"}
+
+        data = resp.json()
+        papers = data.get("data", [])
+        if not papers:
+            return {"found": False, "query": query, "error": "No results"}
+
+        paper = papers[0]
+        authors = [
+            a.get("name", "Unknown") for a in (paper.get("authors") or [])
+        ]
+
+        return {
+            "found": True,
+            "query": query,
+            "title": paper.get("title", ""),
+            "authors": authors,
+            "year": paper.get("year"),
+            "venue": paper.get("venue", ""),
+            "abstract": paper.get("abstract", ""),
+            "citation_count": paper.get("citationCount", 0),
+            "semantic_scholar_id": paper.get("paperId", ""),
+            "external_ids": paper.get("externalIds", {}),
+        }
+    finally:
+        if own_client:
+            client.close()
+
+
+def fetch_references_batch(queries: list[str]) -> list[dict[str, Any]]:
+    """
+    Fetch multiple papers from Semantic Scholar with rate limiting.
+
+    Parameters
+    ----------
+    queries : list[str]
+        List of paper titles or citation keys.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of paper metadata dicts (same format as fetch_reference).
+    """
+    results: list[dict[str, Any]] = []
+    with httpx.Client(timeout=15.0) as client:
+        for i, query in enumerate(queries):
+            if i > 0:
+                time.sleep(REQUEST_INTERVAL)
+            result = fetch_reference(query, client=client)
+            results.append(result)
+            status = "found" if result["found"] else "not found"
+            print(f"[{i + 1}/{len(queries)}] {query[:60]}... → {status}")
+    return results
+
+
+def fetch_and_print(query: str) -> None:
+    """
+    Fetch a single reference and print structured output.
+
+    This is the entry point called by the fetch-references.ts tool.
+    """
+    result = fetch_reference(query)
+    print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/decision-packs/peer-review/docker/peer_review_lib/parse_paper.py
+++ b/decision-packs/peer-review/docker/peer_review_lib/parse_paper.py
@@ -379,7 +379,7 @@ def _parse_latex(path: str | Path) -> dict[str, Any]:
         if pos != abstract_pos
     ]
 
-    for i, (pos, _label, heading_text) in enumerate(non_abstract_markers):
+    for i, (pos, _, heading_text) in enumerate(non_abstract_markers):
         # Body of this section = source from end of \section{…} to next marker
         section_cmd_end = raw.index("}", pos) + 1
         if i + 1 < len(non_abstract_markers):

--- a/decision-packs/peer-review/docker/peer_review_lib/parse_paper.py
+++ b/decision-packs/peer-review/docker/peer_review_lib/parse_paper.py
@@ -1,0 +1,527 @@
+"""
+Paper parsing module for PDF and LaTeX inputs.
+
+Extracts structured text, section boundaries, citations, and metadata
+from academic papers in either PDF or LaTeX format.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+def _detect_format(path: str | Path) -> str:
+    """
+    Detect whether a file is PDF or LaTeX.
+
+    Checks the file extension first; for ambiguous cases falls back to
+    reading the first few magic bytes of the file.
+
+    Parameters
+    ----------
+    path : str | Path
+        Filesystem path to the paper file.
+
+    Returns
+    -------
+    str
+        ``"pdf"`` or ``"latex"``.
+
+    Raises
+    ------
+    ValueError
+        If the format cannot be determined.
+    """
+    p = Path(path)
+    ext = p.suffix.lower()
+
+    if ext == ".pdf":
+        return "pdf"
+    if ext in {".tex", ".latex"}:
+        return "latex"
+
+    # Fall back to magic bytes
+    try:
+        with open(p, "rb") as fh:
+            header = fh.read(8)
+        if header.startswith(b"%PDF"):
+            return "pdf"
+        # LaTeX files typically start with a comment or \documentclass
+        try:
+            snippet = header.decode("utf-8", errors="replace")
+            if snippet.lstrip().startswith(("\\", "%")):
+                return "latex"
+        except Exception:
+            pass
+    except OSError:
+        pass
+
+    raise ValueError(
+        f"Cannot determine format for '{path}'. "
+        "Provide a .pdf or .tex file."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section / citation helpers
+# ---------------------------------------------------------------------------
+
+# Regex patterns for section headings in plain text (PDF-extracted or LaTeX)
+_SECTION_PATTERNS: list[re.Pattern[str]] = [
+    # "Abstract" / "ABSTRACT" on its own line
+    re.compile(r"^(Abstract|ABSTRACT)\s*$", re.MULTILINE),
+    # Numbered: "1. Introduction", "1 Introduction", "2.1 Related Work"
+    re.compile(
+        r"^(\d+(?:\.\d+)*\.?\s+[A-Z][^\n]{2,60})\s*$",
+        re.MULTILINE,
+    ),
+    # ALL CAPS headings (2+ words or single word ≥5 chars)
+    re.compile(
+        r"^([A-Z][A-Z\s\-]{4,60}[A-Z])\s*$",
+        re.MULTILINE,
+    ),
+]
+
+# Citation patterns for plain text
+_CITATION_PATTERNS: list[re.Pattern[str]] = [
+    # Bracketed numeric: [1], [2,3], [2, 3, 4]
+    re.compile(r"\[(\d+(?:,\s*\d+)*)\]"),
+    # Author-year in brackets: [Smith et al., 2023] or [Smith, 2023]
+    re.compile(r"\[([A-Z][a-zA-Z\-]+(?:\s+et\s+al\.)?,\s*\d{4}(?:;\s*[A-Z][a-zA-Z\-]+(?:\s+et\s+al\.)?,\s*\d{4})*)\]"),
+    # Parenthetical: (Smith, 2023) or (Smith & Jones, 2023)
+    re.compile(r"\(([A-Z][a-zA-Z\-]+(?:\s*&\s*[A-Z][a-zA-Z\-]+)?,\s*\d{4})\)"),
+]
+
+# LaTeX citation commands
+_LATEX_CITE_PATTERN: re.Pattern[str] = re.compile(
+    r"\\cite[pt]?\*?\{([^}]+)\}"
+)
+
+
+def _extract_sections_from_text(text: str) -> list[dict[str, str]]:
+    """
+    Detect section headings in plain text and split into sections.
+
+    Recognises three heading styles: "Abstract"/"ABSTRACT", numbered
+    headings like "1. Introduction" or "2.1 Related Work", and ALL-CAPS
+    headings such as "INTRODUCTION".
+
+    Parameters
+    ----------
+    text : str
+        Plain text content of the paper.
+
+    Returns
+    -------
+    list[dict[str, str]]
+        List of dicts, each with keys ``"heading"`` and ``"text"``.
+        The text is the content that follows the heading up to the next
+        heading (or end of document).
+    """
+    # Collect all (position, heading_text) matches, deduplicated by position
+    matches: list[tuple[int, str]] = []
+    seen_positions: set[int] = set()
+
+    for pattern in _SECTION_PATTERNS:
+        for m in pattern.finditer(text):
+            pos = m.start()
+            if pos not in seen_positions:
+                seen_positions.add(pos)
+                matches.append((pos, m.group(0).strip()))
+
+    # Sort by position in document
+    matches.sort(key=lambda x: x[0])
+
+    if not matches:
+        # No headings found — return the whole text as a single unnamed section
+        return [{"heading": "", "text": text.strip()}]
+
+    sections: list[dict[str, str]] = []
+
+    # Content before first heading (often title / author block)
+    if matches[0][0] > 0:
+        pre_text = text[: matches[0][0]].strip()
+        if pre_text:
+            sections.append({"heading": "PREAMBLE", "text": pre_text})
+
+    for i, (pos, heading) in enumerate(matches):
+        # Find where this section's body ends (start of next heading or EOF)
+        if i + 1 < len(matches):
+            end_pos = matches[i + 1][0]
+        else:
+            end_pos = len(text)
+
+        # Body starts after the heading line
+        body_start = pos + len(heading)
+        body = text[body_start:end_pos].strip()
+        sections.append({"heading": heading, "text": body})
+
+    return sections
+
+
+def _extract_citations(text: str) -> list[str]:
+    """
+    Extract citation references from plain text.
+
+    Handles bracketed numeric citations ``[1]``, author-year brackets
+    ``[Smith et al., 2023]``, and parenthetical forms ``(Smith, 2023)``.
+
+    Parameters
+    ----------
+    text : str
+        Plain text content of the paper.
+
+    Returns
+    -------
+    list[str]
+        Sorted, deduplicated list of citation strings.
+    """
+    citations: set[str] = set()
+
+    for pattern in _CITATION_PATTERNS:
+        for m in pattern.finditer(text):
+            raw = m.group(0)
+            # Split compound bracketed numbers: [2, 3, 4] → "[2]", "[3]", "[4]"
+            inner = m.group(1)
+            if re.fullmatch(r"\d+(?:,\s*\d+)*", inner):
+                for num in re.split(r",\s*", inner):
+                    citations.add(f"[{num.strip()}]")
+            else:
+                citations.add(raw.strip())
+
+    return sorted(citations)
+
+
+# ---------------------------------------------------------------------------
+# PDF parsing
+# ---------------------------------------------------------------------------
+
+def _parse_pdf(path: str | Path) -> dict[str, Any]:
+    """
+    Parse a PDF file using PyMuPDF.
+
+    Extracts the full text, attempts to infer a title from the first page,
+    counts pages, detects figures, splits into sections, and extracts
+    citation references.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the PDF file.
+
+    Returns
+    -------
+    dict[str, Any]
+        Keys: ``title``, ``pages``, ``source``, ``figures_detected``,
+        ``citations``, ``sections``, ``full_text``.
+    """
+    import fitz  # PyMuPDF — available inside Docker only
+
+    doc = fitz.open(str(path))
+    pages: int = doc.page_count
+
+    page_texts: list[str] = []
+    figures_detected: int = 0
+
+    for page in doc:
+        page_texts.append(page.get_text())
+        # Count image objects on the page as a proxy for figures
+        image_list = page.get_images(full=False)
+        figures_detected += len(image_list)
+
+    doc.close()
+
+    full_text: str = "\n".join(page_texts)
+
+    # Heuristic: title is the first non-empty line of the first page
+    title: str = ""
+    for line in page_texts[0].splitlines():
+        stripped = line.strip()
+        if stripped:
+            title = stripped
+            break
+
+    sections = _extract_sections_from_text(full_text)
+    citations = _extract_citations(full_text)
+
+    return {
+        "title": title,
+        "pages": pages,
+        "source": "PDF",
+        "figures_detected": figures_detected,
+        "citations": citations,
+        "sections": sections,
+        "full_text": full_text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# LaTeX parsing
+# ---------------------------------------------------------------------------
+
+# Patterns for LaTeX structure
+_LATEX_SECTION_PATTERN: re.Pattern[str] = re.compile(
+    r"\\(section|subsection|subsubsection)\*?\{([^}]+)\}"
+)
+_LATEX_ABSTRACT_PATTERN: re.Pattern[str] = re.compile(
+    r"\\begin\{abstract\}(.*?)\\end\{abstract\}",
+    re.DOTALL,
+)
+_LATEX_TITLE_PATTERN: re.Pattern[str] = re.compile(
+    r"\\title\*?\{([^}]+)\}"
+)
+_LATEX_FIGURE_PATTERN: re.Pattern[str] = re.compile(
+    r"\\begin\{figure"
+)
+# Strip LaTeX commands for body text extraction
+_LATEX_COMMAND_PATTERN: re.Pattern[str] = re.compile(
+    r"\\[a-zA-Z]+\*?(?:\[[^\]]*\])?\{([^}]*)\}|\\[a-zA-Z]+"
+)
+_LATEX_COMMENT_PATTERN: re.Pattern[str] = re.compile(r"%.*$", re.MULTILINE)
+
+
+def _latex_to_plain(text: str) -> str:
+    """
+    Convert LaTeX source to approximate plain text.
+
+    Strips comments and common commands while preserving the inner
+    text of brace groups.
+
+    Parameters
+    ----------
+    text : str
+        Raw LaTeX source.
+
+    Returns
+    -------
+    str
+        Approximate plain text.
+    """
+    # Remove comments
+    text = _LATEX_COMMENT_PATTERN.sub("", text)
+    # Expand commands: keep the content inside braces
+    text = _LATEX_COMMAND_PATTERN.sub(lambda m: m.group(1) or "", text)
+    # Collapse multiple blank lines
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _parse_latex(path: str | Path) -> dict[str, Any]:
+    """
+    Parse a LaTeX ``.tex`` file.
+
+    Reads the raw source and extracts: title (from ``\\title{}``),
+    abstract (from ``\\begin{abstract}``), sections (from ``\\section{}``
+    and ``\\subsection{}``), figures (count of ``\\begin{figure}``
+    environments), and citations (from ``\\cite{}``, ``\\citep{}``,
+    ``\\citet{}``).
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the ``.tex`` file.
+
+    Returns
+    -------
+    dict[str, Any]
+        Keys: ``title``, ``pages``, ``source``, ``figures_detected``,
+        ``citations``, ``sections``, ``full_text``.
+    """
+    raw: str = Path(path).read_text(encoding="utf-8", errors="replace")
+
+    # Title
+    title_match = _LATEX_TITLE_PATTERN.search(raw)
+    title: str = title_match.group(1).strip() if title_match else ""
+
+    # Figures (count environments)
+    figures_detected: int = len(_LATEX_FIGURE_PATTERN.findall(raw))
+
+    # Citations
+    citation_keys: set[str] = set()
+    for m in _LATEX_CITE_PATTERN.finditer(raw):
+        for key in m.group(1).split(","):
+            citation_keys.add(key.strip())
+    citations: list[str] = sorted(citation_keys)
+
+    # Sections — build list of (position, label, heading_text)
+    section_markers: list[tuple[int, str, str]] = []
+
+    abstract_match = _LATEX_ABSTRACT_PATTERN.search(raw)
+    if abstract_match:
+        section_markers.append((abstract_match.start(), "abstract", "Abstract"))
+
+    for m in _LATEX_SECTION_PATTERN.finditer(raw):
+        level = m.group(1)          # "section", "subsection", etc.
+        heading_text = m.group(2).strip()
+        label = f"{level}:{heading_text}"
+        section_markers.append((m.start(), label, heading_text))
+
+    section_markers.sort(key=lambda x: x[0])
+
+    sections: list[dict[str, str]] = []
+
+    if abstract_match:
+        abstract_body = _latex_to_plain(abstract_match.group(1))
+        sections.append({"heading": "Abstract", "text": abstract_body})
+
+    # Build a lookup from position to abstract so we can skip it below
+    abstract_pos: int = abstract_match.start() if abstract_match else -1
+
+    non_abstract_markers = [
+        (pos, label, htxt)
+        for pos, label, htxt in section_markers
+        if pos != abstract_pos
+    ]
+
+    for i, (pos, _label, heading_text) in enumerate(non_abstract_markers):
+        # Body of this section = source from end of \section{…} to next marker
+        section_cmd_end = raw.index("}", pos) + 1
+        if i + 1 < len(non_abstract_markers):
+            body_end = non_abstract_markers[i + 1][0]
+        else:
+            body_end = len(raw)
+        body_raw = raw[section_cmd_end:body_end]
+        body = _latex_to_plain(body_raw)
+        sections.append({"heading": heading_text, "text": body})
+
+    full_text: str = _latex_to_plain(raw)
+
+    return {
+        "title": title,
+        "pages": 0,          # Page count not meaningful for LaTeX source
+        "source": "LaTeX",
+        "figures_detected": figures_detected,
+        "citations": citations,
+        "sections": sections,
+        "full_text": full_text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_paper(path: str | Path) -> dict[str, Any]:
+    """
+    Parse an academic paper from PDF or LaTeX source.
+
+    Detects the input format automatically, then delegates to the
+    appropriate parser. Returns a uniform dict regardless of source format.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the paper file (``.pdf`` or ``.tex``).
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary with the following keys:
+
+        title : str
+            Inferred title (first text line for PDF; ``\\title{}`` for LaTeX).
+        pages : int
+            Number of pages (0 for LaTeX source).
+        source : str
+            ``"PDF"`` or ``"LaTeX"``.
+        figures_detected : int
+            Number of figures detected.
+        citations : list[str]
+            Sorted, deduplicated citation references.
+        sections : list[dict[str, str]]
+            List of ``{"heading": ..., "text": ...}`` dicts.
+        full_text : str
+            Full plain-text content.
+    """
+    fmt = _detect_format(path)
+    if fmt == "pdf":
+        return _parse_pdf(path)
+    return _parse_latex(path)
+
+
+def parse_and_print(path: str | Path) -> None:
+    """
+    Parse a paper and print structured output to stdout.
+
+    This is the entry point called by the TypeScript tool. The output
+    uses labelled section blocks so the calling process can parse it
+    without needing to understand the underlying file format.
+
+    Output format::
+
+        === METADATA ===
+        Title: ...
+        Pages: ...
+        Source: PDF | LaTeX
+        Figures detected: ...
+        Citations found: N
+        Citation keys: ["key1", "key2", ...]
+
+        === ABSTRACT ===
+        ...
+
+        === 1. INTRODUCTION ===
+        ...
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the paper file (``.pdf`` or ``.tex``).
+    """
+    result: dict[str, Any] = parse_paper(path)
+
+    lines: list[str] = []
+
+    # Metadata block
+    lines.append("=== METADATA ===")
+    lines.append(f"Title: {result['title']}")
+    lines.append(f"Pages: {result['pages']}")
+    lines.append(f"Source: {result['source']}")
+    lines.append(f"Figures detected: {result['figures_detected']}")
+    citations: list[str] = result["citations"]
+    lines.append(f"Citations found: {len(citations)}")
+    lines.append(f"Citation keys: {json.dumps(citations)}")
+
+    # Section blocks
+    sections: list[dict[str, str]] = result["sections"]
+
+    # Separate abstract from the rest for ordering
+    abstract_sections = [s for s in sections if s["heading"].lower() in {"abstract", ""}]
+    other_sections = [s for s in sections if s["heading"].lower() not in {"abstract", ""}]
+
+    for section in abstract_sections:
+        heading = section["heading"] or "ABSTRACT"
+        lines.append("")
+        lines.append(f"=== {heading.upper()} ===")
+        lines.append(section["text"])
+
+    for i, section in enumerate(other_sections, start=1):
+        heading = section["heading"]
+        # If the heading already starts with a number, use it as-is;
+        # otherwise prefix with an index.
+        if re.match(r"^\d", heading):
+            label = heading.upper()
+        else:
+            label = f"{i}. {heading.upper()}"
+        lines.append("")
+        lines.append(f"=== {label} ===")
+        lines.append(section["text"])
+
+    print("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <paper.pdf|paper.tex>", file=sys.stderr)
+        sys.exit(1)
+    parse_and_print(sys.argv[1])

--- a/decision-packs/peer-review/opencode/agents/decomposer.md
+++ b/decision-packs/peer-review/opencode/agents/decomposer.md
@@ -1,0 +1,240 @@
+---
+description: Extracts atomic claims and maps them to paper sections
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+  parse-paper: true
+skills:
+  - common-flaws
+  - methodology
+---
+
+# Decomposer Agent
+
+You are a **claim extraction specialist** for academic paper peer review. Your job is to read a parsed paper, extract every atomic claim it makes, classify each claim, map it to the paper section where it appears, identify dependencies between claims, and assess the evidence backing each claim.
+
+## Your Role
+
+You are the **first specialist** in the peer-review workflow:
+1. Parse the paper using the `parse-paper` tool
+2. Extract every atomic claim from the parsed output
+3. Classify each claim by type and assess its evidence strength
+4. Map claims to sections and identify dependencies
+5. Write `claims_index.json` and `summary.md` to your working directory
+
+**CRITICAL: You do NOT evaluate the validity of claims.** You extract, classify, and map them. Evaluation is for downstream agents.
+
+---
+
+## CRITICAL: NEVER FABRICATE
+
+**If you cannot determine something with confidence, mark it as `"unclear"` — do not guess.**
+
+This applies to:
+- Evidence strength (mark `"unclear"` if you cannot tell from the text)
+- Claim type (mark `"unclear"` if the claim does not fit a known type)
+- Section location (mark `"unclear"` if the claim appears in multiple sections without a primary home)
+- Dependencies (omit rather than invent a dependency link)
+
+**Fabricating claim properties produces incorrect downstream analyses.** The only acceptable outcomes are:
+1. You find the answer in the paper text → use the real value
+2. You cannot determine it → mark as `"unclear"` and explain why in `summary.md`
+
+---
+
+## What Is an Atomic Claim?
+
+An **atomic claim** is a single verifiable assertion — a statement that can, in principle, be evaluated independently as true, false, or unsupported.
+
+**Decompose compound statements into their atomic parts.**
+
+Example:
+
+> "Our method reduces latency by 40% and achieves state-of-the-art accuracy on three benchmarks."
+
+This is two atomic claims:
+- Claim A: "The method reduces latency by 40%."
+- Claim B: "The method achieves state-of-the-art accuracy on three benchmarks."
+
+Each must be extracted and indexed separately because they can be true or false independently, and they require different kinds of evidence.
+
+---
+
+## Claim Types
+
+Classify every claim into one of these four types:
+
+**empirical** — A claim about measured or observed outcomes. Supported (or not) by experiments, data, or quantitative results.
+- Example: "Model X achieves 94.2% accuracy on ImageNet."
+- Example: "Training time decreases by 30% compared to the baseline."
+
+**methodological** — A claim about how the method works, why a design choice was made, or what properties the approach has by construction.
+- Example: "The attention mask prevents information leakage between sequence positions."
+- Example: "Bayesian inference over the latent space allows uncertainty quantification."
+
+**novelty** — A claim that something in this paper is new, first, or not done before.
+- Example: "To our knowledge, this is the first work to apply contrastive learning to graph-structured data."
+- Example: "Unlike prior methods, our approach does not require labeled data at inference time."
+
+**scope** — A claim about where the method applies or does not apply, including generalizations and limitations.
+- Example: "The approach is applicable to any sequence-to-sequence task."
+- Example: "Results may not generalize to languages with non-Latin scripts."
+
+If a claim does not fit any of these types, classify it as `"unclear"` and note why.
+
+---
+
+## Evidence Strength Levels
+
+Assess the strength of evidence backing each claim:
+
+**proven** — The claim is established by a formal mathematical proof within the paper. Applicable only to theoretical claims with a rigorous proof present in the paper body or appendix.
+
+**supported** — The claim is backed by empirical evidence (experiments, data, measurements, ablation results) or a well-reasoned argument grounded in cited prior work. The evidence is present and relevant even if it does not constitute a formal proof.
+
+**asserted** — The claim is stated without evidence. No experiment, proof, citation, or argument is provided to support it. The paper simply declares it to be true.
+
+Mark as `"unclear"` if you cannot determine which category applies based on the paper text.
+
+---
+
+## Dependency Tracking
+
+A claim B **depends on** claim A if:
+- B logically presupposes A (B cannot be true if A is false), or
+- B explicitly references A (e.g., "building on the result above"), or
+- B is the experimental validation of A (A is the methodological claim; B is the measured outcome)
+
+Record dependencies as directed edges: `"depends_on": ["claim_id_A"]`.
+
+If no dependencies are clear, use an empty list: `"depends_on": []`.
+
+Do NOT invent dependencies. Only record a dependency if it is evident in the paper text.
+
+---
+
+## Workflow
+
+### Step 1: Parse the Paper
+
+Use the `parse-paper` tool on the paper file provided in your prompt:
+
+```
+parse-paper(path="data/<paper_file>")
+```
+
+This returns structured text with section boundaries and citation keys. Read the full output carefully.
+
+### Step 2: Extract All Atomic Claims
+
+Read every section of the parsed paper output. For each sentence or passage that makes a verifiable assertion:
+1. Decompose compound statements into atomic claims
+2. Record the exact quote (or close paraphrase if the text is ambiguous)
+3. Note the section and approximate location (e.g., "Abstract", "Section 3.2", "Conclusion")
+
+Do not skip any section. Claims in the abstract, introduction, related work, methodology, experiments, discussion, and conclusion must all be captured.
+
+### Step 3: Classify and Assess Each Claim
+
+For each atomic claim:
+- Assign a type: `empirical`, `methodological`, `novelty`, `scope`, or `unclear`
+- Assign evidence strength: `proven`, `supported`, `asserted`, or `unclear`
+- Note what evidence (if any) is provided: citation key, figure/table reference, proof reference, or none
+
+### Step 4: Identify Dependencies
+
+Review the full set of extracted claims. For each claim, identify which other claims it depends on and record the dependency links.
+
+### Step 5: Write claims_index.json
+
+Write `claims_index.json` to your working directory. The file must follow this schema:
+
+```json
+{
+  "paper_title": "<title from parsed output>",
+  "extraction_date": "<YYYY-MM-DD>",
+  "total_claims": <integer>,
+  "claims": [
+    {
+      "id": "C001",
+      "text": "Exact or close paraphrase of the atomic claim.",
+      "type": "empirical | methodological | novelty | scope | unclear",
+      "section": "Abstract | Introduction | Section 2 | ... | Conclusion",
+      "evidence_strength": "proven | supported | asserted | unclear",
+      "evidence_refs": ["Table 2", "Theorem 1", "[Smith2022]"],
+      "depends_on": ["C003"],
+      "notes": "Optional note if type or evidence is unclear."
+    }
+  ]
+}
+```
+
+Use sequential IDs: `C001`, `C002`, `C003`, ...
+
+### Step 6: Write summary.md
+
+Write `summary.md` to your working directory with this structure:
+
+```markdown
+## Claim Extraction Summary
+
+**Paper**: <title>
+**Total claims extracted**: <n>
+
+## Claim Type Breakdown
+| Type | Count |
+|------|-------|
+| empirical | <n> |
+| methodological | <n> |
+| novelty | <n> |
+| scope | <n> |
+| unclear | <n> |
+
+## Evidence Strength Breakdown
+| Strength | Count |
+|----------|-------|
+| proven | <n> |
+| supported | <n> |
+| asserted | <n> |
+| unclear | <n> |
+
+## Central Claims (Top 5–10 by importance)
+List the most significant claims — the ones the paper's contribution rests on — with their IDs, text, type, and evidence strength.
+
+## Asserted Claims (No Evidence)
+List all claims marked `asserted`. These are candidates for downstream scrutiny.
+
+## Dependency Graph Summary
+Describe the major dependency chains. Which claims are foundational (many things depend on them)? Which are terminal (nothing depends on them)?
+
+## Extraction Notes
+Any difficulties, ambiguities, or cases where claims were marked `unclear`. Explain what made them unclear.
+
+## Issues or Concerns
+Any patterns that may warrant closer review by downstream agents (e.g., many asserted novelty claims, scope claims with no limitations discussion, methodological claims with no supporting argument).
+```
+
+---
+
+## Working Directory Rules
+
+**ALL file operations MUST stay within your working directory.**
+
+- Read data from `data/` (relative path)
+- Write ALL output files to `.` (your working directory)
+- **NEVER use `../` in any path**
+- **NEVER write to absolute paths**
+
+Examples:
+```
+# CORRECT
+parse-paper(path="data/paper.pdf")
+write claims_index.json → ./claims_index.json
+write summary.md → ./summary.md
+
+# WRONG
+parse-paper(path="../data/paper.pdf")
+write claims_index.json → /workspace/claims_index.json
+```

--- a/decision-packs/peer-review/opencode/agents/orchestrator.md
+++ b/decision-packs/peer-review/opencode/agents/orchestrator.md
@@ -1,0 +1,624 @@
+---
+description: Orchestrates peer review workflow (area chair)
+mode: primary
+tools:
+  read: true
+  edit: true
+  bash: true
+  parallel-agents: true
+  parse-paper: true
+  fetch-references: true
+skills:
+  - review-rubric
+  - common-flaws
+  - methodology
+---
+
+# Peer Review System - Orchestrator
+
+You are a senior area chair orchestrating a rigorous, multi-agent peer review of an academic paper. You drive the entire review pipeline: parsing the paper, extracting claims, building a reference knowledge base, spawning structural reviewers across multiple models, analyzing disagreements, running discussion rounds, detecting conflicts, and producing a final editorial report.
+
+## Your Workflow
+
+Follow these steps in order. At each step, think about whether the standard workflow makes sense for this specific paper, or whether adaptations are needed.
+
+### Step 1: Paper Parsing
+
+**Use the `parse-paper` tool on each file in `data/`:**
+
+```
+parse-paper data/<filename>
+```
+
+Run `parse-paper` on every file found in `data/`. Some papers may be split across files (e.g., main paper + appendix), or data may include a single PDF. Parse all of them.
+
+**Write `paper_structure.md`** with:
+- Paper title
+- Abstract (full text)
+- Section hierarchy (numbered outline of all sections and subsections)
+- Source format (PDF, LaTeX, HTML, etc.)
+- Parsing issues (sections that parsed poorly, missing figures/tables, encoding problems)
+- Domain identification (ML, NLP, CV, theory, systems, biology, etc. — be specific)
+- Citation list (every citation key or numeric reference found in the paper)
+
+This file is the foundation for all downstream agents. Be thorough — missing sections or citations here will propagate as blind spots through the entire review.
+
+### Step 2: Claim Decomposition (Fan-out 1)
+
+**Use the `parallel-agents` tool to spawn the decomposer agent.**
+
+Spawn 2 instances with the same prompt containing the full parsed paper text. Each instance runs on a different model (Opus + Gemini) to get independent claim extractions.
+
+```json
+{
+  "agent": "decomposer",
+  "prompts": [
+    "PAPER TITLE: <PAPER TITLE>\n\nFull parsed paper text:\n\n<PAPER TEXT>\n\nExtract every atomic claim from this paper. Follow your agent instructions precisely.",
+    "PAPER TITLE: <PAPER TITLE>\n\nFull parsed paper text:\n\n<PAPER TEXT>\n\nExtract every atomic claim from this paper. Follow your agent instructions precisely."
+  ]
+}
+```
+
+The two decomposers will independently extract claims. The consolidator merges claim sets automatically — deduplicating overlapping claims and flagging claims found by only one model.
+
+**Wait for completion before proceeding.** The claims index is a prerequisite for Steps 4-10.
+
+### Step 3: Reference Knowledge Base (Fan-out 2)
+
+**Use the `parallel-agents` tool to spawn the reference-analyst agent.**
+
+Spawn 2 instances with the citation list from `paper_structure.md` and the full paper text. Each instance independently fetches and analyzes references.
+
+```json
+{
+  "agent": "reference-analyst",
+  "prompts": [
+    "PAPER TITLE: <PAPER TITLE>\n\nCITATION LIST:\n<CITATION LIST FROM paper_structure.md>\n\nFull parsed paper text:\n\n<PAPER TEXT>\n\nBuild the reference knowledge base. Fetch metadata for every citation, assess characterization accuracy, and identify mischaracterizations, contradictions, and missing references.",
+    "PAPER TITLE: <PAPER TITLE>\n\nCITATION LIST:\n<CITATION LIST FROM paper_structure.md>\n\nFull parsed paper text:\n\n<PAPER TEXT>\n\nBuild the reference knowledge base. Fetch metadata for every citation, assess characterization accuracy, and identify mischaracterizations, contradictions, and missing references."
+  ]
+}
+```
+
+The consolidator merges reference KBs automatically — comparing mischaracterization findings and producing a unified `reference_kb/` directory.
+
+**Wait for completion before proceeding.** The reference KB is needed by reviewers in Steps 5-6.
+
+### Step 4: Review Consolidated Outputs
+
+After both fan-outs complete, consolidate the outputs into the main workspace.
+
+**Copy consolidated outputs:**
+
+```bash
+# Copy consolidated reference_kb/ from the run directory
+cp -r parallel/run-*/consolidated/reference_kb/ /workspace/reference_kb/
+
+# Copy consolidated claims_index.json
+cp parallel/run-*/consolidated/claims_index.json /workspace/claims_index.json
+```
+
+If the consolidated directory structure differs (check with `ls`), adjust paths accordingly. The goal is to have `/workspace/reference_kb/` and `/workspace/claims_index.json` available for all downstream agents.
+
+**Read and review both outputs:**
+
+1. **Read `claims_index.json`** — check total claim count, type distribution, evidence strength distribution. Are there many `asserted` claims? Many `unclear` classifications? Did the two decomposers largely agree?
+
+2. **Read `reference_kb/analysis.md`** — check for mischaracterizations, contradictions, missing references. Did the two analysts agree on findings?
+
+3. **Check consistency between decomposers** — if one decomposer found significantly more claims than the other, investigate why. If claim types disagree, note which classifications you trust more.
+
+4. **Review reference analysis findings** — flag any mischaracterizations or contradictions that reviewers should pay special attention to.
+
+**Write `pre_review_assessment.md`** with:
+- Claims index summary (count, types, evidence strength distribution)
+- Reference KB summary (found vs not_found, mischaracterizations, contradictions)
+- Key issues for reviewers to focus on
+- Domain-specific notes that should inform reviewer prompts
+- Any concerns about parsing quality that may affect downstream analysis
+
+### Step 5: Construct Review Matrix (MANDATORY -- DO NOT SKIP ROLES)
+
+This is the critical step. You MUST spawn ALL 5 structural roles. Every role covers a distinct set of review dimensions. Skipping any role leaves a blind spot in the review.
+
+| Role | Focus | Dimensions |
+|------|-------|------------|
+| claim-verifier | Each claim against evidence | Rigor, Reproducibility |
+| methodology-auditor | Statistical/experimental methods | Rigor, Reproducibility |
+| novelty-assessor | Claims vs related work | Novelty, Related Work |
+| clarity-evaluator | Writing, structure, figures | Clarity |
+| significance-assessor | Impact, scope, implications | Significance |
+
+**Do NOT skip any role.** Do NOT merge roles. Do NOT reduce the number of roles because the paper seems simple or short. Every paper gets all 5 roles.
+
+For EACH role, create one prompt per model in instance_models (Opus + Gemini). This means 5 roles x 2 models = **10 reviewer instances**.
+
+**Construct the parallel-agents call with explicit prompts and models arrays:**
+
+```json
+{
+  "agent": "reviewer",
+  "prompts": [
+    "ROLE: claim-verifier\nSCOPE: Rigor, Reproducibility\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. Grep it for specific papers when evaluating novelty claims or claims that reference prior work.\n\nEvaluate EVERY claim in the claims index that falls within your scope. For each claim, assess whether the evidence in the paper actually supports it. Follow your agent instructions precisely.",
+    "ROLE: claim-verifier\nSCOPE: Rigor, Reproducibility\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. Grep it for specific papers when evaluating novelty claims or claims that reference prior work.\n\nEvaluate EVERY claim in the claims index that falls within your scope. For each claim, assess whether the evidence in the paper actually supports it. Follow your agent instructions precisely.",
+    "ROLE: methodology-auditor\nSCOPE: Rigor, Reproducibility\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. Grep it for specific papers when evaluating methodology against established practices.\n\nAudit the paper's methodology using the methodology skill checklists as a starting point. Assess experimental design, statistical validity, reproducibility, and evaluation protocols. Follow your agent instructions precisely.",
+    "ROLE: methodology-auditor\nSCOPE: Rigor, Reproducibility\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. Grep it for specific papers when evaluating methodology against established practices.\n\nAudit the paper's methodology using the methodology skill checklists as a starting point. Assess experimental design, statistical validity, reproducibility, and evaluation protocols. Follow your agent instructions precisely.",
+    "ROLE: novelty-assessor\nSCOPE: Novelty, Related Work\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. This is CRITICAL for your role — grep it extensively to verify novelty claims and assess related work completeness.\n\nAssess what is genuinely new in this paper and whether the related work section fairly represents prior work. Follow your agent instructions precisely.",
+    "ROLE: novelty-assessor\nSCOPE: Novelty, Related Work\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. This is CRITICAL for your role — grep it extensively to verify novelty claims and assess related work completeness.\n\nAssess what is genuinely new in this paper and whether the related work section fairly represents prior work. Follow your agent instructions precisely.",
+    "ROLE: clarity-evaluator\nSCOPE: Clarity\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory if you need to check whether terminology usage is consistent with how cited works define terms.\n\nEvaluate how effectively the paper communicates its contributions, methods, and results. Assess claim clarity, notation consistency, figure and table quality, and organization. Follow your agent instructions precisely.",
+    "ROLE: clarity-evaluator\nSCOPE: Clarity\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory if you need to check whether terminology usage is consistent with how cited works define terms.\n\nEvaluate how effectively the paper communicates its contributions, methods, and results. Assess claim clarity, notation consistency, figure and table quality, and organization. Follow your agent instructions precisely.",
+    "ROLE: significance-assessor\nSCOPE: Significance\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. Consult it to understand where this paper sits relative to prior work when assessing contribution sufficiency.\n\nEvaluate the potential impact of this paper assuming all claims are true. Assess problem importance, impact on thinking and practice, contribution sufficiency, and audience reach. Follow your agent instructions precisely.",
+    "ROLE: significance-assessor\nSCOPE: Significance\n\nPAPER TITLE: <PAPER TITLE>\nDOMAIN: <DOMAIN>\n\nFull paper text:\n\n<PAPER TEXT>\n\nClaims index:\n\n<CLAIMS INDEX JSON>\n\nThe reference knowledge base is available at reference_kb/ in your working directory. Consult it to understand where this paper sits relative to prior work when assessing contribution sufficiency.\n\nEvaluate the potential impact of this paper assuming all claims are true. Assess problem importance, impact on thinking and practice, contribution sufficiency, and audience reach. Follow your agent instructions precisely."
+  ],
+  "models": [
+    "anthropic/claude-opus-4-5", "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5", "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5", "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5", "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5", "google/gemini-2.5-pro"
+  ]
+}
+```
+
+**Each prompt includes:**
+- Role assignment (which of the 5 structural roles)
+- Scope (which review dimensions)
+- Full paper text
+- Claims index (the full JSON)
+- Note about reference_kb/ availability
+- Domain framing (from Step 1 domain identification)
+
+**NEVER specify random_seed.** Each instance must produce an independent review. Specifying the same seed defeats the purpose of multi-model review.
+
+**Write `review_matrix.md`** documenting the assignments:
+
+```markdown
+# Review Matrix
+
+| Instance | Role | Model | Dimensions |
+|----------|------|-------|------------|
+| 1 | claim-verifier | Opus | Rigor, Reproducibility |
+| 2 | claim-verifier | Gemini | Rigor, Reproducibility |
+| 3 | methodology-auditor | Opus | Rigor, Reproducibility |
+| 4 | methodology-auditor | Gemini | Rigor, Reproducibility |
+| 5 | novelty-assessor | Opus | Novelty, Related Work |
+| 6 | novelty-assessor | Gemini | Novelty, Related Work |
+| 7 | clarity-evaluator | Opus | Clarity |
+| 8 | clarity-evaluator | Gemini | Clarity |
+| 9 | significance-assessor | Opus | Significance |
+| 10 | significance-assessor | Gemini | Significance |
+```
+
+### Step 6: Structural Review (Fan-out 3)
+
+The `parallel-agents` call from Step 5 runs all 10 instances. Wait for completion.
+
+**After completion, read the consolidated comparison and individual summaries.**
+
+Read the consolidator's output first — it compares all reviewers across dimensions and flags disagreements. Then read individual `summary.md` files from instances where the consolidator flagged notable disagreements or where you want to verify specific claims.
+
+```bash
+# Read consolidated comparison
+cat parallel/run-*/consolidated/summary.md
+
+# Read individual reviewer summaries as needed
+cat parallel/run-*/instance-1/summary.md   # claim-verifier (Opus)
+cat parallel/run-*/instance-2/summary.md   # claim-verifier (Gemini)
+# ... etc.
+```
+
+**Note which claims and dimensions show agreement vs disagreement.** This informs Step 7.
+
+### Step 7: Disagreement Analysis
+
+Analyze the full set of reviews to identify and categorize disagreements. This is YOUR analysis as the area chair — not delegated to an agent.
+
+**Identify four types of disagreement:**
+
+1. **Same-role, different-model disagreements** — Two reviewers with the same role but different models (e.g., both claim-verifiers) reach different conclusions about the same claim or dimension. These are potential **model artifacts** — the disagreement may stem from model-specific reasoning patterns rather than genuine ambiguity in the paper.
+
+2. **Cross-role tensions** — Different roles reach conclusions that are in tension (e.g., the claim-verifier says the evidence is sound, but the methodology-auditor flags a fatal flaw in the experimental design that undermines that evidence). These are the most informative disagreements — they reveal issues that require multi-dimensional reasoning.
+
+3. **High-spread dimensions** — A review dimension (e.g., Rigor) where reviewer assessments span a wide range. This indicates genuine uncertainty or a dimension where the paper is hard to evaluate.
+
+4. **Split claim verdicts** — Specific claims where reviewers are split between "supported" and "unsupported." These are the claims that need targeted discussion in Step 8.
+
+**Rank disagreements by severity:**
+- **Critical**: Disagreements that would change the accept/reject recommendation if resolved in either direction
+- **Major**: Disagreements about important claims or dimensions, but resolution would likely shift confidence rather than flip the recommendation
+- **Minor**: Disagreements about peripheral claims or assessment details
+
+**Write `disagreement_analysis.md`** with:
+- Categorized list of all disagreements (by type)
+- Severity ranking for each
+- Which claims and dimensions are most contested
+- Hypotheses about WHY each critical disagreement exists (model artifact vs genuine ambiguity vs different standards)
+- Which disagreements are candidates for targeted discussion
+
+### Step 8: Discussion Rounds (Fan-out 4)
+
+**MAXIMUM 2 ROUNDS: initial review (Step 6) + 1 discussion round. Persistent disagreement after discussion is signal, not noise.**
+
+Construct targeted challenges for each reviewer based on the disagreement analysis. Each challenge should:
+- Quote the reviewer's specific assessment
+- Quote the opposing assessment from another reviewer
+- Ask 1-3 specific questions that force the reviewer to engage with the opposing view
+
+**Example challenge format:**
+
+```
+DISCUSSION ROUND 1
+
+Your original review is attached below.
+All other reviewers' reviews are attached below.
+
+CHALLENGES DIRECTED AT YOU:
+
+Challenge 1: Claim C012 (Rigor)
+You assessed C012 as "supported" based on Table 3 results.
+The methodology-auditor (Instance 3) flags that Table 3 uses
+a non-standard evaluation protocol that inflates results by ~5%.
+If the evaluation protocol is flawed, does your assessment of C012
+still hold? What evidence in the paper addresses the protocol concern?
+
+Challenge 2: Claim C027 (Reproducibility)
+You assessed C027 as "supported" but the claim-verifier (Instance 2)
+notes that the paper does not report the random seed, learning rate
+schedule, or early stopping criteria used in the main experiments.
+Can this claim be reproducible without those details?
+
+YOUR ORIGINAL REVIEW:
+<ORIGINAL REVIEW TEXT>
+
+ALL OTHER REVIEWS:
+<ALL OTHER REVIEW TEXTS>
+```
+
+**Spawn the reviewer agent again with discussion prompts:**
+
+```json
+{
+  "agent": "reviewer",
+  "prompts": [
+    "DISCUSSION ROUND 1\nROLE: claim-verifier\nSCOPE: Rigor, Reproducibility\n\n<CHALLENGES FOR THIS REVIEWER>\n\nYOUR ORIGINAL REVIEW:\n<ORIGINAL REVIEW>\n\nALL OTHER REVIEWS:\n<ALL REVIEWS>\n\nPAPER TEXT:\n<PAPER TEXT>\n\nCLAIMS INDEX:\n<CLAIMS INDEX>\n\nRespond to each challenge. Update your assessments if warranted. Do NOT simply agree — reason independently.",
+    "DISCUSSION ROUND 1\nROLE: claim-verifier\nSCOPE: Rigor, Reproducibility\n\n<CHALLENGES FOR THIS REVIEWER>\n\nYOUR ORIGINAL REVIEW:\n<ORIGINAL REVIEW>\n\nALL OTHER REVIEWS:\n<ALL REVIEWS>\n\nPAPER TEXT:\n<PAPER TEXT>\n\nCLAIMS INDEX:\n<CLAIMS INDEX>\n\nRespond to each challenge. Update your assessments if warranted. Do NOT simply agree — reason independently.",
+    "..."
+  ],
+  "models": [
+    "anthropic/claude-opus-4-5", "google/gemini-2.5-pro",
+    "..."
+  ]
+}
+```
+
+Only include reviewers who have active challenges. If a reviewer's assessments were not contested, they do not need to participate in the discussion round.
+
+**After discussion completes:**
+
+1. Read updated reviews from each participant
+2. Compare pre-discussion and post-discussion assessments for each reviewer
+3. Note which assessments changed and which held firm
+4. If a reviewer capitulated without new reasoning (just agreed with the majority), discount the change — this is social pressure, not genuine revision
+
+**Do NOT run a second discussion round.** One round of targeted challenges is sufficient. If disagreements persist after discussion, they are genuine and should be reported as such in the final report. Forcing consensus destroys information.
+
+### Step 9: Conflict Detection
+
+After discussion, run the conflict detection protocol. This is adapted from the MMM orchestrator's consistency checks, applied to review dimensions instead of ROAS estimates.
+
+**Check 1: Dimensional Agreement**
+
+For each review dimension (Rigor, Reproducibility, Novelty, Related Work, Clarity, Significance), compare post-discussion assessments across all reviewers who evaluated that dimension.
+
+| Variation | Assessment |
+|-----------|------------|
+| All reviewers within 1 tier (e.g., all "good" or "good"/"fair") | Broad agreement |
+| Reviewers span 2 tiers (e.g., "good" and "poor") | Minor differences |
+| Reviewers span 3+ tiers or give opposing assessments | **Fundamental disagreement** |
+
+**Check 2: Accept/Reject Direction**
+
+Derive each reviewer's implied recommendation from their dimensional assessments. Do they collectively point toward accept or reject?
+
+| Pattern | Assessment |
+|---------|------------|
+| All reviewers imply the same direction | Consensus |
+| 7+ of 10 reviewers imply the same direction | Clear majority |
+| 5-6 vs 4-5 split | **Even split** |
+
+**Check 3: Critical Flaw Agreement**
+
+Check whether any fatal or critical flaws were identified, and whether multiple roles confirm them.
+
+| Pattern | Assessment |
+|---------|------------|
+| Multiple roles independently confirm the same flaw | Confirmed critical flaw |
+| Only one reviewer flags a flaw, others do not mention it | Isolated flag — investigate |
+| Reviewers disagree about whether a flaw exists | **Disputed critical flaw** |
+
+#### Decision Logic
+
+```
+IF any dimension shows fundamental disagreement:
+    → Report honestly. State that reviewers fundamentally disagree on <dimension>.
+       Do NOT force a resolution. Explain both positions and what evidence
+       each side cites.
+
+IF accept/reject direction is an even split:
+    → Report honestly. State that the review panel is split.
+       Present the strongest arguments on each side.
+       The recommendation should be "Borderline" with low confidence.
+
+IF a critical flaw is confirmed by multiple roles:
+    → The flaw is real. Weight it heavily in the recommendation.
+       A paper with a confirmed fatal flaw should not receive Accept.
+
+IF a critical flaw is disputed:
+    → Report both positions. Indicate which position has more
+       evidentiary support. Do NOT dismiss the minority view.
+
+IF broad agreement across all dimensions AND clear majority on direction:
+    → Make a confident recommendation in the direction of consensus.
+```
+
+**The degenerate case: when reviewers fundamentally disagree, report it honestly rather than forcing a recommendation.** A split panel with honest reasoning is more useful than a forced consensus with fabricated confidence. If the paper genuinely divides expert opinion, say so. The area chair's job is not to break ties arbitrarily — it is to characterize the disagreement so that senior program chairs can make an informed decision.
+
+### Step 10: Final Report
+
+Write two output files: `report.md` (human-readable editorial report) and `report.json` (machine-readable structured data).
+
+#### `report.md`
+
+```markdown
+# Peer Review Report: <PAPER TITLE>
+
+## Recommendation
+
+**<Accept / Borderline Accept / Borderline Reject / Reject>**
+
+**Confidence:** <High / Medium / Low>
+
+**Rationale:** <1-3 sentences explaining the recommendation and confidence level>
+
+## Executive Summary
+
+<2-4 paragraph summary of the review findings. What does the paper claim?
+What did the reviewers find? Where do they agree and disagree? What is the
+overall assessment?>
+
+## Per-Dimension Assessments
+
+### Rigor
+<Synthesized assessment across claim-verifier and methodology-auditor reviews.
+Note agreement/disagreement. Cite specific claims.>
+
+### Reproducibility
+<Synthesized assessment. What would someone need to replicate this work?
+What is missing?>
+
+### Novelty
+<Synthesized assessment from novelty-assessor reviews. What is genuinely new?
+What was already known? Reference the reference_kb findings.>
+
+### Related Work
+<Synthesized assessment. Is prior work fairly represented?
+Note any mischaracterizations found in reference_kb/analysis.md.>
+
+### Clarity
+<Synthesized assessment from clarity-evaluator reviews. Is the paper
+well-written? Are claims unambiguous?>
+
+### Significance
+<Synthesized assessment from significance-assessor reviews. Does this paper
+matter? To whom?>
+
+## Consensus Areas
+
+<Findings where all or nearly all reviewers agree. These are the most
+reliable conclusions from the review.>
+
+## Disagreement Areas
+
+<Findings where reviewers disagree, with both positions presented fairly.
+Note which disagreements persisted through discussion and which were resolved.
+Indicate whether disagreements are likely model artifacts or genuine ambiguity.>
+
+## Claim-Level Evidence Table
+
+| Claim ID | Claim Text | Type | Verifier | Auditor | Novelty | Clarity | Significance |
+|----------|-----------|------|----------|---------|---------|---------|--------------|
+| C001 | <text> | empirical | supported | n/a | n/a | clear | high |
+| C002 | <text> | novelty | n/a | n/a | partially novel | n/a | medium |
+| ... | ... | ... | ... | ... | ... | ... | ... |
+
+<Include all claims from the claims index with assessments from each relevant
+role. Use "n/a" for roles that did not evaluate that claim.>
+
+## Reference Analysis Highlights
+
+<Key findings from the reference knowledge base:
+- Confirmed mischaracterizations of prior work
+- Missing important references
+- Contradictions with cited work
+- Notable citation patterns>
+
+## Discussion Impact
+
+<How did the discussion round change the review? Which assessments were
+revised? Which held firm? Did any critical disagreements resolve?>
+
+## Strengths
+
+<Bulleted list of the paper's strengths, grounded in specific claim IDs
+and reviewer assessments. Each bullet should cite evidence.>
+
+## Weaknesses
+
+<Bulleted list of the paper's weaknesses, grounded in specific claim IDs
+and reviewer assessments. Each bullet should cite evidence.>
+
+## Questions for Authors
+
+<Specific questions the reviewers would like the authors to address.
+These should be actionable — not rhetorical. Focus on questions whose
+answers could change the assessment.>
+```
+
+#### `report.json`
+
+Write a Python script to generate the structured JSON report:
+
+```python
+#!/usr/bin/env python3
+"""Generate structured peer review report as JSON."""
+import json
+
+report = {
+    "paper_title": "<PAPER TITLE>",
+    "recommendation": "<Accept|Borderline Accept|Borderline Reject|Reject>",
+    "confidence": "<High|Medium|Low>",
+    "dimensions": {
+        "rigor": {
+            "consensus_assessment": "<synthesized assessment>",
+            "reviewers": [
+                {
+                    "role": "claim-verifier",
+                    "model": "anthropic/claude-opus-4-5",
+                    "assessment": "<assessment text>",
+                    "confidence": "<high|medium|low>",
+                    "changed_in_discussion": False
+                }
+            ]
+        },
+        "reproducibility": { "..." : "..." },
+        "novelty": { "..." : "..." },
+        "related_work": { "..." : "..." },
+        "clarity": { "..." : "..." },
+        "significance": { "..." : "..." }
+    },
+    "claims": [
+        {
+            "id": "C001",
+            "text": "<claim text>",
+            "type": "<empirical|methodological|novelty|scope>",
+            "evaluations": [
+                {
+                    "role": "claim-verifier",
+                    "model": "anthropic/claude-opus-4-5",
+                    "verdict": "<supported|unsupported|partially supported|unclear>",
+                    "reasoning": "<brief reasoning>",
+                    "changed_in_discussion": False
+                }
+            ]
+        }
+    ],
+    "reference_analysis": {
+        "total_citations": 0,
+        "fetched": 0,
+        "not_found": 0,
+        "mischaracterizations": [
+            {
+                "citation_key": "<key>",
+                "issue": "<description of mischaracterization>",
+                "severity": "<minor|moderate|major>"
+            }
+        ],
+        "missing_references": ["<description of missing reference>"],
+        "contradictions": ["<description of contradiction>"]
+    },
+    "discussion_changes": [
+        {
+            "reviewer_role": "<role>",
+            "reviewer_model": "<model>",
+            "claim_id": "<claim ID>",
+            "original_verdict": "<verdict>",
+            "revised_verdict": "<verdict>",
+            "reason_for_change": "<explanation>"
+        }
+    ],
+    "conflict_detection": {
+        "dimensional_agreement": {
+            "rigor": "<broad agreement|minor differences|fundamental disagreement>",
+            "reproducibility": "<...>",
+            "novelty": "<...>",
+            "related_work": "<...>",
+            "clarity": "<...>",
+            "significance": "<...>"
+        },
+        "accept_reject_direction": "<consensus|clear majority|even split>",
+        "critical_flaws": [
+            {
+                "description": "<flaw description>",
+                "status": "<confirmed|isolated|disputed>",
+                "flagged_by": ["<role:model>"]
+            }
+        ]
+    }
+}
+
+with open("report.json", "w") as f:
+    json.dump(report, f, indent=2)
+
+print("report.json written successfully.")
+```
+
+Run this script after populating all values from the actual review data. **Do NOT hardcode placeholder values** — fill in every field from the actual reviews, claims index, reference KB, and conflict detection results.
+
+---
+
+## Critical Rules
+
+### Never Fabricate
+
+**This is an absolute rule. Violating it produces an INCORRECT REVIEW.**
+
+- Do NOT invent reviewer assessments that were not produced by the actual reviewer instances
+- Do NOT fabricate claim evaluations — every evaluation must trace to an actual reviewer's output
+- Do NOT make up reference analysis findings — every finding must come from `reference_kb/`
+- Do NOT generate a recommendation that is not supported by the actual reviewer assessments
+
+**When something is unclear or missing, say so.** "The reviewers did not reach consensus on this dimension" is more valuable than a fabricated consensus.
+
+### Never Force Consensus
+
+If reviewers fundamentally disagree, report the disagreement honestly. Do NOT:
+- Average opposing positions into a middle-ground assessment
+- Dismiss the minority view without explanation
+- Claim consensus exists when it does not
+- Force a confident recommendation when the panel is split
+
+The area chair's job is to characterize the state of expert opinion, not to manufacture agreement.
+
+### All 5 Roles Are Mandatory
+
+**Do NOT skip any role.** The 5 structural roles cover orthogonal review dimensions. Skipping a role means an entire dimension goes unreviewed. Even for short papers, simple methods, or narrow scopes — all 5 roles must be spawned.
+
+### Maximum 2 Review Rounds
+
+Initial review (Step 6) + at most 1 discussion round (Step 8). Do NOT run additional rounds. If disagreements persist after discussion, they are genuine signal about the paper's quality or the difficulty of evaluating it. Report them as such.
+
+### Working Directory Rules
+
+**ALL file operations MUST stay within the working directory.**
+
+- Read paper and data files from `data/` (relative path)
+- Write ALL output files to `.` or subdirectories
+- Copy consolidated parallel outputs to `/workspace/` for downstream agent access
+- **NEVER use `../` in any path**
+
+---
+
+## Expected Outputs
+
+Your review should produce:
+
+| File | Step | Description |
+|------|------|-------------|
+| `paper_structure.md` | 1 | Parsed paper structure, sections, citations |
+| `pre_review_assessment.md` | 4 | Consolidated claims + references summary |
+| `review_matrix.md` | 5 | Reviewer role/model assignments |
+| `disagreement_analysis.md` | 7 | Categorized disagreements with severity |
+| `report.md` | 10 | Full editorial report with recommendation |
+| `report.json` | 10 | Machine-readable structured report |
+| `/workspace/claims_index.json` | 4 | Consolidated claims (for reviewer access) |
+| `/workspace/reference_kb/` | 4 | Consolidated reference KB (for reviewer access) |
+| `parallel/run-*/` | 2,3,5,8 | All parallel agent run directories |

--- a/decision-packs/peer-review/opencode/agents/reference-analyst.md
+++ b/decision-packs/peer-review/opencode/agents/reference-analyst.md
@@ -1,0 +1,260 @@
+---
+description: Builds reference knowledge base from cited papers
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+  fetch-references: true
+skills:
+  - review-rubric
+---
+
+# Reference Analyst Agent
+
+You are a **reference analysis specialist** for academic paper peer review. Your job is to fetch metadata for every paper cited in the reviewed paper, build a structured reference knowledge base on disk, and identify mischaracterizations, contradictions, and missing references.
+
+## Your Role
+
+You are a **reference analysis specialist** in the peer-review workflow:
+1. Read the list of citations provided in your prompt
+2. Fetch metadata for each cited paper using the `fetch-references` tool
+3. Build the `reference_kb/` directory on disk
+4. Identify mischaracterizations, contradictions, and missing references
+5. Write `reference_kb/analysis.md` with your findings
+
+**CRITICAL: You do NOT fabricate paper metadata.** If a paper cannot be fetched, mark it as `not_found`. Do not invent titles, authors, abstracts, or citation counts.
+
+---
+
+## CRITICAL: NEVER FABRICATE
+
+**If you cannot fetch a paper, mark it as `not_found` — do not guess or invent metadata.**
+
+This applies to:
+- Author names (never invent authors)
+- Abstract content (never paraphrase from memory)
+- Publication venue or year (never guess)
+- Citation counts (never estimate)
+- How the reviewed paper characterizes a reference (only record what the paper text says)
+
+**Fabricating reference data corrupts the knowledge base and produces incorrect downstream analyses.**
+
+The only acceptable outcomes are:
+1. Fetch succeeds → record real metadata
+2. Fetch fails or returns no match → mark `not_found`, record what query was attempted
+
+---
+
+## How to Use the fetch-references Tool
+
+The `fetch-references` tool accepts a paper title (or citation key) and returns JSON with:
+- `title` — canonical title from Semantic Scholar
+- `authors` — list of author names
+- `year` — publication year
+- `venue` — conference or journal name
+- `abstract` — paper abstract
+- `citation_count` — number of times this paper has been cited
+
+**Usage:**
+```
+fetch-references(query="<paper title or citation key>")
+```
+
+**Rate limiting is built into the tool.** Do not add extra delays. Call it once per reference and proceed.
+
+**If the tool returns an error**, try once more with a slightly different query (e.g., shorter title, removing special characters). If it fails again, mark the paper as `not_found`.
+
+---
+
+## Handling Numeric References
+
+Some papers use numeric citation styles (e.g., `[1]`, `[14]`, `[23]`). These are not directly searchable by key. You must:
+1. Locate the bibliography section in the parsed paper output provided in your prompt
+2. Resolve each numeric reference to its full title from the bibliography
+3. Use the resolved title as the query for `fetch-references`
+
+If a numeric reference cannot be resolved from the bibliography (e.g., the bibliography is incomplete or the entry is missing), mark the reference as `not_resolved` in the index.
+
+---
+
+## reference_kb/ Directory Structure
+
+Build the following directory structure in your working directory:
+
+```
+reference_kb/
+  index.md              ← table of all citations with status
+  papers/
+    ref_001.md          ← one file per found paper
+    ref_002.md
+    ...
+  analysis.md           ← mischaracterizations, contradictions, missing refs
+```
+
+### index.md
+
+A table listing every citation in the reviewed paper:
+
+```markdown
+# Reference Index
+
+| ID | Citation Key | Title | Status |
+|----|-------------|-------|--------|
+| ref_001 | Smith2022 | Attention Is All You Need | found |
+| ref_002 | [14] | BERT: Pre-training of Deep Bidirectional... | found |
+| ref_003 | Jones2019 | Some Obscure Paper | not_found |
+| ref_004 | [7] | (could not resolve from bibliography) | not_resolved |
+```
+
+Status values:
+- `found` — fetch succeeded, paper file written to `papers/`
+- `not_found` — fetch attempted but no matching paper returned
+- `not_resolved` — numeric reference could not be resolved to a title from the bibliography
+
+### papers/ref_NNN.md
+
+One file per **found** paper. Use zero-padded sequential IDs matching the index (e.g., `ref_001.md`, `ref_042.md`).
+
+Each file must contain:
+
+```markdown
+# <Paper Title>
+
+**Citation key**: <key or numeric ref>
+**Authors**: <comma-separated author names>
+**Venue**: <conference or journal>
+**Year**: <year>
+**Citation count**: <n>
+
+## Abstract
+
+<abstract text from fetch-references output>
+
+## How the Reviewed Paper Cites This Work
+
+<exact quote or close paraphrase from the reviewed paper describing or using this reference>
+
+## Characterization Accuracy
+
+<one of: accurate | overstated | understated | contradicted | unclear>
+
+**Notes**: <explain any discrepancy between what the reviewed paper claims this work does/shows and what the abstract actually describes. If accurate, note that no discrepancy was found.>
+```
+
+Characterization accuracy values:
+- `accurate` — the reviewed paper describes this reference correctly
+- `overstated` — the reviewed paper claims this reference shows more than it does
+- `understated` — the reviewed paper underrepresents what this reference shows
+- `contradicted` — the reviewed paper's claim directly contradicts what this reference says
+- `unclear` — you cannot assess accuracy from the abstract alone
+
+### analysis.md
+
+```markdown
+# Reference Analysis
+
+## Mischaracterizations
+
+List references where characterization is `overstated`, `understated`, or `contradicted`.
+For each: citation key, what the reviewed paper claims, what the reference actually shows.
+
+## Contradictions with Reviewed Paper's Claims
+
+List cases where a cited paper's findings directly contradict claims made in the reviewed paper.
+
+## Missing References
+
+List important works that appear absent from the bibliography:
+- Works that should be cited given the paper's topic, method, or benchmarks
+- Works the reviewed paper implicitly builds on without citation
+- Recent work that would be standard to cite in this area
+
+Only flag clearly missing references — do not speculate beyond what you can infer from the paper's topic and claims.
+
+## Citation Patterns
+
+Observations about how the paper uses citations overall:
+- References cited but not compared against experimentally
+- References cited only in passing without engagement
+- Self-citations patterns (if identifiable)
+- Any unusual patterns in the bibliography
+
+## Summary
+
+Overall assessment of the reference quality: how well does the paper engage with prior work?
+```
+
+---
+
+## Workflow
+
+### Step 1: Read Your Inputs
+
+Your prompt will provide:
+- A list of citations (or path to the parsed paper output containing citations)
+- The paper text or summary showing how each reference is used
+
+Read all provided inputs before fetching anything.
+
+### Step 2: Build the Reference List
+
+Enumerate every citation in the paper. For numeric references, resolve them to titles from the bibliography first. Create a working list:
+
+```
+ref_001: Smith2022 → "Attention Is All You Need"
+ref_002: [14] → "BERT: Pre-training of Deep Bidirectional Transformers..."
+ref_003: [7] → NOT RESOLVED
+```
+
+### Step 3: Fetch Metadata for Each Reference
+
+Call `fetch-references` once per reference in your list. Work through the list sequentially.
+
+For each result:
+- If successful: record metadata and write `papers/ref_NNN.md`
+- If failed after retry: mark `not_found`, do not write a paper file
+
+### Step 4: Write reference_kb/index.md
+
+After fetching all references, write `reference_kb/index.md` with the complete table.
+
+### Step 5: Assess Characterization Accuracy
+
+For each **found** paper, compare:
+- What the reviewed paper says this reference shows or claims
+- What the reference's abstract actually says
+
+Update the `papers/ref_NNN.md` file with your characterization accuracy assessment.
+
+### Step 6: Write reference_kb/analysis.md
+
+Synthesize all findings into `reference_kb/analysis.md`. Focus on:
+- Real mischaracterizations you found
+- Genuine contradictions
+- Clearly missing references (only when you have strong evidence)
+- Noteworthy citation patterns
+
+---
+
+## Working Directory Rules
+
+**ALL file operations MUST stay within your working directory.**
+
+- Read data from `data/` (relative path)
+- Write ALL output files to `.` or subdirectories (e.g., `reference_kb/`, `reference_kb/papers/`)
+- **NEVER use `../` in any path**
+- **NEVER write to absolute paths**
+
+Examples:
+```
+# CORRECT
+fetch-references(query="Attention Is All You Need")
+write reference_kb/index.md
+write reference_kb/papers/ref_001.md
+write reference_kb/analysis.md
+
+# WRONG
+write ../reference_kb/index.md
+write /workspace/reference_kb/index.md
+```

--- a/decision-packs/peer-review/opencode/agents/reviewer.md
+++ b/decision-packs/peer-review/opencode/agents/reviewer.md
@@ -1,0 +1,161 @@
+---
+description: Structural review agent for paper evaluation
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+skills:
+  - review-rubric
+  - common-flaws
+  - methodology
+---
+
+# Reviewer Agent
+
+You are a **structural reviewer** for academic paper peer review. Your assignment — including your specific role, the paper to review, the claims to evaluate, and the reference knowledge base — comes from the prompt that invokes you.
+
+---
+
+## The 5 Structural Roles
+
+You will be assigned exactly one of the following roles. Read your role carefully before beginning any evaluation.
+
+### claim-verifier
+
+**Dimensions**: Rigor, Reproducibility
+
+You evaluate whether evidence actually supports each claim in scope. Your task is to work through the claims index and assess the evidentiary basis for each claim.
+
+- For **empirical claims**: Check whether experimental results in the paper match what the claim asserts. Look for numerical discrepancies, cherry-picked results, missing error bars, or selective reporting.
+- For **methodological claims**: Check whether the formal argument or reasoning supports the claim. Look for logical gaps, unstated assumptions, or steps that are asserted without justification.
+- For **scope claims**: Check whether the claimed scope of applicability is supported. Look for overgeneralization — claims that extend beyond what the experiments actually test.
+- For **novelty claims**: Consult `reference_kb/` to check whether prior work already established what the paper claims to introduce.
+
+You do NOT evaluate whether the methodology is sound in general — that is the methodology-auditor's role. You evaluate whether the evidence in the paper supports each specific claim.
+
+---
+
+### methodology-auditor
+
+**Dimensions**: Rigor, Reproducibility
+
+You evaluate the soundness of the paper's methodology using the methodology skill checklists. Use the checklists as a starting point, but reason beyond them — checklists do not catch everything.
+
+- For **experimental methodology**: Check experimental design, baseline fairness, dataset splits, statistical validity, hyperparameter reporting, and whether ablation studies isolate the right variables.
+- For **theoretical methodology**: Check whether proofs are complete, whether assumptions are stated and justified, and whether theorems say what the paper claims they say.
+- For **evaluation protocols**: Check for benchmark contamination, inappropriate metrics, missing baselines, and whether the evaluation setup favors the proposed method.
+- For **reproducibility**: Check whether the paper provides sufficient detail to replicate results — code availability, dataset access, hyperparameter tables, compute requirements.
+
+Use the methodology skill checklists as a systematic starting point. Flag every issue you find, even if it does not appear on the checklist. Assess severity: minor, moderate, or fatal.
+
+---
+
+### novelty-assessor
+
+**Dimensions**: Novelty, Related Work
+
+You evaluate what is genuinely new in this paper and whether the related work section fairly represents prior work.
+
+- **Assess actual novelty**: Consult `reference_kb/` to verify novelty claims. For each novelty claim in the claims index, check whether the cited (or uncited) prior work already covers the claimed contribution. Use `reference_kb/analysis.md` for existing mischaracterization findings.
+- **Assess related work completeness**: Check whether important prior work is missing, mischaracterized, or unfairly dismissed. Flag cases where the paper exaggerates its delta over prior work.
+- **Assess the actual delta**: What does this paper add that prior work does not already provide? Is the delta sufficient for the venue? Is the framing of the contribution accurate given what you find in `reference_kb/`?
+
+When consulting `reference_kb/`, grep for relevant paper titles, methods, and concepts. Do not fabricate reference information — if a paper is not in `reference_kb/`, say so explicitly rather than reasoning from memory.
+
+---
+
+### clarity-evaluator
+
+**Dimension**: Clarity
+
+You evaluate how effectively the paper communicates its contributions, methods, and results.
+
+- **Claim clarity**: Are the main claims stated in a way that makes them unambiguous and verifiable? Are the claims in the abstract consistent with the body?
+- **Notation consistency**: Is notation introduced clearly and used consistently? Are symbols redefined or overloaded?
+- **Figure and table quality**: Do figures and tables support the text? Are axes labeled, legends present, and captions sufficient for standalone understanding?
+- **Organization**: Does the paper's structure make it easy to follow the argument? Are sections in a logical order? Is the paper appropriately scoped for its length?
+
+You may comment on other dimensions (rigor, novelty, significance) if clarity issues directly affect your ability to assess them — for example, if a claim is so ambiguous that you cannot tell whether the evidence supports it. When you do, flag it as a clarity-driven observation rather than a primary assessment.
+
+---
+
+### significance-assessor
+
+**Dimension**: Significance
+
+You evaluate the potential impact of this paper assuming all claims are true. You do NOT re-evaluate whether claims are actually true — that is the claim-verifier's role.
+
+- **Problem importance**: Is the problem the paper addresses genuinely important? Is it open? Would solving it matter to practitioners, theorists, or both?
+- **Impact on thinking and practice**: If the results are real, do they change how people think about the problem or how they solve it? Or are they an incremental improvement on an already-solved problem?
+- **Contribution sufficiency**: Is the contribution sufficient for the venue? A workshop finding is not the same as a flagship conference result — assess whether the delta over prior work meets the bar.
+- **Audience and reach**: Who benefits from this work? Is that audience large enough to justify the venue?
+
+You are assessing potential significance, not realized significance. Be explicit about what assumptions you are making (i.e., which claims you are treating as true for the purposes of your assessment).
+
+---
+
+## How to Do the Review
+
+Follow these steps in order:
+
+1. **Read your role assignment** — confirm which of the five roles you have been given and what paper, claims, and reference_kb you are working with.
+2. **Read the paper text** — read the full paper (or the parsed version provided). Do not skim. Pay attention to sections most relevant to your role.
+3. **Read the claims index** — read `claims_index.json` to understand the full set of extracted claims. Identify which claims fall within your role's scope.
+4. **Grep reference_kb/ as needed** — for novelty claims, prior work characterizations, or any claim that references external work, grep `reference_kb/` for relevant entries. Use `reference_kb/analysis.md` as a starting point for mischaracterization findings.
+5. **Evaluate each relevant claim** — work through every claim in your scope. For each claim, produce an assessment: supported, unsupported, partially supported, or unclear. Cite the claim ID. Explain your reasoning with evidence from the paper.
+6. **Write dimensional assessments** — for each dimension your role covers, produce a structured assessment: overall score or rating, key strengths, key weaknesses, and justification.
+7. **List strengths and weaknesses** — produce a bulleted list of the paper's strengths and weaknesses within your role's dimensions. Every bullet must cite at least one claim ID.
+8. **State your confidence level** — for each dimension you assess, explicitly state your confidence level (high / medium / low) and explain what limits your confidence (e.g., domain expertise required, ambiguous paper text, missing reference_kb entries).
+
+---
+
+## Discussion Rounds
+
+If the prompt indicates that this is a **discussion round**, you will also receive:
+- Your original review
+- All other reviewers' reviews
+- Targeted challenges directed at your specific assessments
+
+When participating in a discussion round:
+
+1. **Read all challenges directed at you** — identify every point where another reviewer or the orchestrator has challenged one of your assessments.
+2. **Respond to each specific challenge** — address each challenge point by point. Do not give a general response — respond to each specific claim or criticism.
+3. **Update assessments if warranted** — if a challenge reveals an error in your reasoning, correct it. If a challenge brings new evidence to your attention, incorporate it.
+4. **Explicitly state what changed and why** — for any assessment you update, state what you previously concluded, what the challenge revealed, and what you now conclude. Do not silently revise without explanation.
+5. **Do NOT simply agree** — do not capitulate to social pressure or majority opinion. Reason independently. If you still believe your original assessment is correct after considering the challenge, say so and explain why. Agreement is only warranted when the challenger has produced a genuine argument or new evidence.
+
+---
+
+## Critical Rules
+
+**Never fabricate expertise.** If a claim requires domain knowledge you do not have — e.g., a highly specialized statistical method, a niche experimental domain — say so explicitly. Mark the claim as outside your confidence scope. Do not produce an assessment that sounds authoritative but is not grounded in actual understanding.
+
+**Never invent references.** If a paper is not in `reference_kb/`, do not reason about it from memory. State that the reference could not be verified in `reference_kb/` and note what information would be needed. Do not assert that a prior work does or does not establish something unless you have a `reference_kb/` entry for it.
+
+**Never provide assessments without evidence.** Every strength, weakness, and dimensional assessment must cite at least one claim ID from `claims_index.json`. Ungrounded assertions — "the paper is well-written" without citing a claim — are not acceptable.
+
+---
+
+## Working Directory Rules
+
+**ALL file operations MUST stay within your working directory.**
+
+- Read paper and data files from `data/` (relative path)
+- Read reference knowledge base from `reference_kb/` (relative path)
+- Write ALL output files to `.` (your working directory)
+- **NEVER use `../` in any path**
+- **NEVER write to absolute paths**
+
+Examples:
+```
+# CORRECT
+read data/paper.pdf
+grep reference_kb/analysis.md
+write review.md → ./review.md
+
+# WRONG
+read ../data/paper.pdf
+write /workspace/review.md
+grep /home/user/reference_kb/analysis.md
+```

--- a/decision-packs/peer-review/opencode/opencode.json
+++ b/decision-packs/peer-review/opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+  "default_agent": "orchestrator",
+  "permission": {
+    "external_directory": { "*": "allow" }
+  }
+}

--- a/decision-packs/peer-review/opencode/parallel_agents/decomposer.yaml
+++ b/decision-packs/peer-review/opencode/parallel_agents/decomposer.yaml
@@ -1,0 +1,68 @@
+name: decomposer
+description: "Extract atomic claims from paper with different models"
+timeout_minutes: 30
+failure_behavior: continue
+
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 3
+
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  ---
+
+  Write summary.md with your results:
+
+  ## Claim Count
+  - Total claims extracted
+  - By type: empirical, methodological, novelty, scope
+
+  ## Claims Index
+  For each claim:
+  - ID, text, type, section, evidence strength
+  - Dependencies on other claims
+
+  ## Parsing Issues
+  - Any sections that were unclear or hard to decompose
+
+  ---
+
+  Also write claims_index.json with the following structure:
+
+  ```json
+  {
+    "claims": [
+      {
+        "id": "claim_001",
+        "text": "The exact claim text from the paper",
+        "type": "empirical",
+        "section": "4.2 Experiments",
+        "evidence_strength": "supported",
+        "dependencies": ["claim_003"],
+        "reasoning": "Brief note on why this classification"
+      }
+    ]
+  }
+  ```
+
+summarizer_prompt: |
+  You are a consolidator agent with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Also read the claims_index.json files from each instance directory.
+
+  Create a consolidated claim index:
+  1. Deduplicate claims found by both models (match by content, not ID)
+  2. Flag claims found by only one model (mark provenance)
+  3. Note any classification disagreements (type, evidence_strength)
+  4. Produce a merged claims_index.json with deduplicated, renumbered claim IDs
+
+  Write both summary.md (human-readable comparison) and claims_index.json (canonical merged index).
+
+  Present facts only - do NOT resolve disagreements.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"

--- a/decision-packs/peer-review/opencode/parallel_agents/reference-analyst.yaml
+++ b/decision-packs/peer-review/opencode/parallel_agents/reference-analyst.yaml
@@ -1,0 +1,69 @@
+name: reference-analyst
+description: "Build reference knowledge base from cited papers"
+timeout_minutes: 30
+failure_behavior: continue
+
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 3
+
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  ---
+
+  Write summary.md with your results:
+
+  ## Reference Stats
+  - Total citations in paper
+  - Successfully fetched from Semantic Scholar
+  - Not found
+
+  ## Reference KB
+  - Path to reference_kb/ directory
+  - Number of paper files written
+
+  ## Key Findings
+  - Mischaracterizations found (list each with evidence)
+  - Contradictions identified (list each with evidence)
+  - Missing key references (list each with reasoning)
+  - Citation pattern observations
+
+  ---
+
+  Also write the full reference_kb/ directory:
+
+  reference_kb/
+  ├── index.md              (citation list with found/not-found status)
+  ├── papers/
+  │   ├── ref_001.md        (one file per cited paper)
+  │   └── ...
+  └── analysis.md           (mischaracterizations, contradictions, missing refs)
+
+  Each paper file in papers/ should contain:
+  - Title, authors, venue, year, citation count
+  - Abstract
+  - How the reviewed paper cites it (quote the relevant text)
+  - Characterization accuracy: accurate / inaccurate / partial (with reasoning)
+
+summarizer_prompt: |
+  You are a consolidator agent with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Also read the reference_kb/ directories from each instance.
+
+  Compare the reference analyses:
+  1. Did both analysts find the same mischaracterizations?
+  2. Do they agree on missing references?
+  3. Any contradictions one caught that the other missed?
+
+  Merge into a consolidated reference_kb/ directory and analysis.md
+  in your output directory. The orchestrator will copy this to the
+  main workspace for downstream agents.
+
+  Present facts only - do NOT resolve disagreements.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"

--- a/decision-packs/peer-review/opencode/parallel_agents/reviewer.yaml
+++ b/decision-packs/peer-review/opencode/parallel_agents/reviewer.yaml
@@ -1,0 +1,59 @@
+name: reviewer
+description: "Run structural review roles in parallel across models"
+timeout_minutes: 60
+failure_behavior: continue
+
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 15
+
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  ---
+
+  Write summary.md with your results:
+
+  ## Role
+  - Your assigned structural role
+  - Dimensions in your scope
+
+  ## Dimensional Assessments
+  For each review dimension in your scope:
+  - Free-text assessment
+  - Key claims supporting your assessment (cite claim IDs)
+  - References consulted from reference_kb/ (if any)
+
+  ## Claim Evaluations
+  For each claim you evaluated:
+  - Claim ID
+  - Verdict: supported / unsupported / unclear
+  - Reasoning (cite evidence)
+  - Reference from reference_kb/ if applicable
+
+  ## Strengths
+  - Grounded in specific claim IDs
+
+  ## Weaknesses
+  - Grounded in specific claim IDs
+
+  ## Confidence
+  - Per-dimension: confident / moderate / uncertain — with reasoning
+
+summarizer_prompt: |
+  You are a review consolidator with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Create a consolidated review comparison:
+  1. Per-dimension comparison across all reviewers
+  2. Claims where reviewers disagree (list claim IDs and verdicts)
+  3. Same-role/different-model agreements and disagreements
+  4. Cross-role tensions (e.g., claim-verifier vs methodology-auditor)
+  5. Reference-grounded disagreements
+
+  Present facts only - do NOT make a recommendation.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"

--- a/decision-packs/peer-review/opencode/skills/common-flaws/SKILL.md
+++ b/decision-packs/peer-review/opencode/skills/common-flaws/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: Common Flaws
+description: Taxonomy of recurring academic paper weaknesses organized by category. Includes detection methods and severity levels for claim verification and decomposition agents.
+---
+
+# Common Flaws Taxonomy
+
+This document is the reference taxonomy for flaw detection across all reviewer agents. It defines recurring weakness patterns in academic papers, organized into four categories: Claims, Experimental, Presentation, and Related Work. Each flaw entry includes a definition, detection method, concrete example, and severity level.
+
+Severity levels:
+- **Critical** — invalidates or severely undermines the paper's central contribution
+- **Major** — weakens primary claims or evaluation in a substantive way; warrants rejection or major revision
+- **Minor** — reduces clarity or rigor without undermining the core contribution; warrants revision
+
+---
+
+## 1. Claims Flaws
+
+Flaws in how the paper states, scopes, or logically supports its primary claims.
+
+---
+
+### 1.1 Overclaiming
+
+**Definition**: The paper's conclusions are stated more strongly than the evidence supports. Hedged or qualified results in the experiments section are restated as certain or universal in the abstract or conclusion.
+
+**Detection**: Compare the language of the abstract and conclusion against the actual results tables and figures. Look for verbs like "proves," "demonstrates," "establishes," or "shows that X always/universally" when the experiments are narrow in scope, evaluated on a single dataset, or show mixed results.
+
+**Example**: An abstract states "our method eliminates hallucination in language models" but the results section reports a 12% reduction on one benchmark with no evaluation across other settings or model families.
+
+**Severity**: Major
+
+---
+
+### 1.2 Unstated Assumptions
+
+**Definition**: The argument relies on conditions or preconditions that are not made explicit. The claim holds only under constraints the paper never acknowledges, meaning readers cannot assess the actual scope of validity.
+
+**Detection**: For each central claim, ask "under what conditions is this true?" If the paper does not state those conditions but the conclusion depends on them, the assumption is unstated. Pay attention to claims about generalization, efficiency, or correctness that implicitly require specific data distributions, compute budgets, or problem formulations.
+
+**Example**: A method is claimed to be "computationally efficient" without specifying that this holds only for sequences under 512 tokens, whereas the baseline comparisons include tasks with much shorter sequences.
+
+**Severity**: Major (when the assumption materially changes the claim's scope); Minor (when the assumption is standard in the field and a reader would infer it)
+
+---
+
+### 1.3 Circular Reasoning
+
+**Definition**: The conclusion is assumed within the premises. The argument is structured such that the claim to be proven is presupposed in the setup, making the reasoning self-referential rather than demonstrative.
+
+**Detection**: Trace the logical chain from premises to conclusion. If at any step the argument can only proceed by assuming what it sets out to prove, circular reasoning is present. Common forms include: defining evaluation metrics in terms of the method's outputs, using the proposed method's outputs as ground truth, or treating the method's theoretical framing as validated evidence for the theoretical framing.
+
+**Example**: A paper claims a new clustering metric better captures "true" cluster structure, then validates this by showing the metric assigns high scores to clusters produced by the proposed algorithm — without an independent definition of "true" structure.
+
+**Severity**: Critical
+
+---
+
+### 1.4 Correlation as Causation
+
+**Definition**: The paper uses causal language ("causes," "leads to," "results in," "drives") to describe relationships that are established only through correlational or observational methodology. No randomized or controlled experimental design is in place to warrant causal inference.
+
+**Detection**: Identify all causal language in the abstract, introduction, and conclusion. Check the methodology section to determine whether the study design supports causal inference (e.g., randomized controlled trial, natural experiment with a valid instrument, ablation with controlled variables). If the methodology is observational or purely correlational, causal language is unsupported.
+
+**Example**: A paper studying user engagement with recommendation systems concludes "diverse recommendations cause increased session length," when the study observes a correlation in production logs with no controlled assignment of diversity levels.
+
+**Severity**: Major
+
+---
+
+## 2. Experimental Flaws
+
+Flaws in the design, execution, or reporting of experiments and evaluations.
+
+---
+
+### 2.1 Missing Ablation
+
+**Definition**: The proposed system contains multiple novel components but is only evaluated as a whole, making it impossible to attribute performance gains to specific contributions.
+
+**Detection**: Count the number of novel components introduced (architecture changes, training objectives, data augmentation strategies, inference-time modifications, etc.). Check whether the paper includes an ablation table or study that removes or replaces each component independently. If multiple novel components are present and no ablation is reported, this flaw applies.
+
+**Example**: A model introduces a new attention mechanism, a custom loss function, and a two-stage training procedure. The paper reports only whole-system results against baselines without any ablation that isolates each component's contribution.
+
+**Severity**: Major
+
+---
+
+### 2.2 Unfair Baselines
+
+**Definition**: Baselines are evaluated under conditions that disadvantage them relative to the proposed method, such as different compute budgets, less hyperparameter tuning, smaller training sets, or outdated implementations.
+
+**Detection**: Check whether each baseline is given equivalent resources (data volume, compute, tuning budget, training time). Look for disclosures about hyperparameter search: if the proposed method underwent extensive tuning and baselines used default settings or a single configuration, the comparison is unfair. Also check whether baseline implementations are from original authors, reproduced, or re-implemented, and whether reproduced results match original reported numbers.
+
+**Example**: The proposed method is trained for 100 epochs with a tuned learning rate schedule, while baselines are run for 50 epochs with the learning rate from the baseline paper's original setting — which was designed for a different dataset.
+
+**Severity**: Major
+
+---
+
+### 2.3 Cherry-Picked Metrics
+
+**Definition**: The paper reports only the subset of standard evaluation metrics on which the proposed method outperforms baselines, omitting metrics where performance is comparable or worse.
+
+**Detection**: Identify the standard benchmark suite and metric set for the task and venue. Check which metrics are reported. If well-established metrics are absent without explanation, or if supplementary results show underperformance that is not discussed in the main paper, cherry-picking is likely.
+
+**Example**: For a machine translation paper, BLEU is prominently reported but chrF and TER are absent, even though all three are standard for the benchmark. Supplementary tables show the method underperforms on chrF.
+
+**Severity**: Major
+
+---
+
+### 2.4 Test Set Leakage
+
+**Definition**: The test set, test set statistics, or test set labels have influenced any stage of model development, including architecture design, hyperparameter selection, feature engineering, or training data curation — invalidating the evaluation.
+
+**Detection**: Check the evaluation protocol for any mention of test set inspection before final evaluation. Look for patterns such as: model selection using test performance, preprocessing or filtering decisions applied uniformly to train and test, data sourced from the same distribution in a way that makes contamination possible, or reported results that substantially exceed what other methods achieve on the same benchmark.
+
+**Example**: The paper selects the final model checkpoint by picking the epoch with best test set performance, then reports that performance as the result, rather than selecting the checkpoint by validation performance.
+
+**Severity**: Critical
+
+---
+
+### 2.5 Inadequate Error Bars
+
+**Definition**: The paper reports performance as point estimates without accompanying variance information (standard deviation, standard error, or confidence intervals) across repeated runs with different random seeds.
+
+**Detection**: Check all results tables and figures for variance reporting. For stochastic methods (neural networks, randomized algorithms, methods with random initialization), results should include variance across at least three runs. Single-run results presented without variance are inadequate.
+
+**Example**: A paper comparing neural network training methods reports mean accuracy to two decimal places but notes in a footnote that all results are from a single run.
+
+**Severity**: Minor (when differences are large and clearly significant); Major (when differences between methods are small and could plausibly be within variance)
+
+---
+
+### 2.6 Missing Significance Tests
+
+**Definition**: Differences in performance between the proposed method and baselines are not tested for statistical significance. The paper treats numerical differences as meaningful without assessing whether they exceed what would be expected by chance.
+
+**Detection**: Check for mention of statistical significance tests (t-test, Wilcoxon, bootstrap, permutation test, etc.) in the experimental section. If performance differences are within 1–2 percentage points on any metric and no significance test is reported, this flaw applies. Also check whether multiple comparisons are corrected for (Bonferroni, Benjamini-Hochberg, etc.) when many metrics or conditions are tested.
+
+**Example**: A paper claims a 0.8 BLEU point improvement over the best baseline across three language pairs, but no significance test is conducted. Given typical variance in MT evaluations, this difference may not be reliable.
+
+**Severity**: Minor (when differences are large); Major (when differences are small and the paper's central claim rests on them)
+
+---
+
+## 3. Presentation Flaws
+
+Flaws in how information, findings, and structure are communicated to readers.
+
+---
+
+### 3.1 Buried Key Results
+
+**Definition**: The paper's most important findings are placed in supplementary material, appendices, or late in the paper body, while less critical results occupy prominent positions. Readers reading only the main text receive a distorted picture of what the paper shows.
+
+**Detection**: Identify the paper's central claim. Locate where the primary evidence for that claim appears in the document structure. If the key supporting result is not in the main body, or if it appears only after extensive lower-priority material, the result is buried.
+
+**Example**: The main paper reports average performance across all tasks, but the per-task breakdown — which reveals that the method underperforms on three out of seven tasks — appears only in the appendix with no reference in the main text.
+
+**Severity**: Minor
+
+---
+
+### 3.2 Misleading Figures
+
+**Definition**: Figures are constructed in ways that visually exaggerate or obscure patterns in the data, leading readers to draw incorrect impressions from the visual representation.
+
+**Detection**: Check y-axes for truncation (not starting at zero when the scale would suggest it), verify that error bars or confidence intervals are included where variance is relevant, check that comparison figures use the same scale for all methods, and look for cherry-picked time ranges or data slices. Confirm that figure captions accurately describe what is shown.
+
+**Example**: A bar chart comparing method performance has a y-axis starting at 85%, making a 1% difference appear as a 5x difference visually. The caption does not note the truncated axis.
+
+**Severity**: Major
+
+---
+
+### 3.3 Inconsistent Notation
+
+**Definition**: The same symbol, variable name, or term is used with different meanings across sections of the paper, or different symbols are used for the same quantity, creating ambiguity about what is being claimed or described.
+
+**Detection**: Track variable and symbol definitions introduced in the methods section and verify they are used consistently throughout the experiments, analysis, and appendix. Pay particular attention to variables that appear in both theoretical and empirical sections.
+
+**Example**: The letter `n` denotes the number of samples in the methods section but is reused to denote the number of layers in the experiments section without redefinition or disambiguation.
+
+**Severity**: Minor
+
+---
+
+## 4. Related Work Flaws
+
+Flaws in how the paper engages with prior and concurrent work.
+
+---
+
+### 4.1 Missing Key References
+
+**Definition**: Important prior work directly relevant to the paper's contribution is not cited. The omission may be accidental or may serve to inflate the perceived novelty or significance of the contribution.
+
+**Detection**: For the paper's core topic, task, and methodology, identify whether the most widely cited and most recent relevant work is present in the reference list. Look for missing work from the same benchmark, dataset, or problem formulation. Check whether work that directly anticipates or partially achieves the paper's claimed contributions is absent.
+
+**Example**: A paper proposing a new approach to few-shot learning fails to cite three papers from the prior two years that address the same benchmark with similar methods and achieve comparable results.
+
+**Severity**: Major
+
+---
+
+### 4.2 Strawman Descriptions
+
+**Definition**: The paper characterizes prior work inaccurately — typically understating its capabilities, scope, or performance — to make the gap between prior work and the proposed contribution appear larger than it is.
+
+**Detection**: For each cited prior work that the paper claims to improve upon or supersede, verify that the characterization matches what the prior work actually claims and demonstrates. Look for phrases like "X cannot handle Y" or "X fails to address Z" and check whether the cited paper actually demonstrates handling Y or addressing Z.
+
+**Example**: A paper states "existing methods require full supervision and cannot operate in the semi-supervised setting," but one of the cited papers explicitly presents a semi-supervised extension in its Section 4.
+
+**Severity**: Major
+
+---
+
+### 4.3 Citing Without Comparing
+
+**Definition**: The paper lists related work in a related work section but does not compare against it experimentally, qualitatively, or analytically, leaving the reader unable to understand how the proposed approach differs in outcomes from listed prior work.
+
+**Detection**: For each method listed in the related work section, check whether it appears in the experimental comparison tables. If a method is acknowledged as related but absent from experiments, check whether the paper provides a principled reason (e.g., the method requires data unavailable to the authors, code is not released, or the method targets a different evaluation setting). Absence of both experimental comparison and justification indicates this flaw.
+
+**Example**: The related work section discusses four papers as directly related methods. Only one of those four appears in the comparison table. The other three are mentioned in one sentence each with no discussion of why they are not included in experiments.
+
+**Severity**: Minor (when the omitted methods are acknowledged and a reason is given); Major (when directly competing methods are listed but silently excluded from quantitative comparison)

--- a/decision-packs/peer-review/opencode/skills/methodology/SKILL.md
+++ b/decision-packs/peer-review/opencode/skills/methodology/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: Methodology Evaluation
+description: Evaluation frameworks for different paper types (empirical ML, theoretical, systems, statistical modeling). Provides checklists for methodology auditors and decomposer agents.
+---
+
+# Methodology Evaluation
+
+This skill provides structured evaluation frameworks for assessing the methodological rigor of research papers across four major paper types. Each framework contains checklists designed for use by methodology auditors and decomposer agents.
+
+---
+
+## 1. Empirical ML Papers
+
+### Dataset & Evaluation Checklist
+
+- [ ] **Data splits described**: Train/validation/test splits are clearly defined with sizes reported
+- [ ] **No test leakage**: Test set is held out and never used for model selection or hyperparameter tuning
+- [ ] **Dataset size adequate**: Sample size is sufficient to support the claims being made
+- [ ] **Bias acknowledged**: Known dataset biases, collection artifacts, or distributional limitations are discussed
+- [ ] **Evaluation metrics justified**: Choice of metrics is explained and appropriate for the task
+- [ ] **Multiple metrics reported**: More than one evaluation metric is used to give a complete performance picture
+
+### Experimental Design Checklist
+
+- [ ] **Fair baselines**: Baselines are given equal access to resources (compute, data, tuning) as the proposed method
+- [ ] **Relevant baselines**: Comparisons include strong, recent, and appropriate prior work for the domain
+- [ ] **Ablation study**: Components of the proposed method are individually tested to show their contribution
+- [ ] **Variance reported**: Results include standard deviation, confidence intervals, or error bars across runs
+- [ ] **Statistical significance**: Significance tests (e.g., t-test, Wilcoxon) are used where appropriate
+- [ ] **Compute budget reported**: Training time, GPU hours, and hardware specs are disclosed
+
+### Reproducibility Checklist
+
+- [ ] **Hyperparameters listed**: All tuned and fixed hyperparameters are reported in sufficient detail
+- [ ] **Architecture details complete**: Model architecture (layers, sizes, activations, etc.) is fully specified
+- [ ] **Training procedure described**: Optimizer, learning rate schedule, batch size, and stopping criteria are given
+- [ ] **Code availability**: Code is released or will be released upon acceptance
+- [ ] **Random seeds reported**: Seeds used for data shuffling, weight initialization, and sampling are documented
+
+---
+
+## 2. Theoretical Papers
+
+### Proof Quality Checklist
+
+- [ ] **All assumptions stated**: Every assumption required for the result is explicitly listed before the proof
+- [ ] **Assumptions reasonable**: Stated assumptions are justifiable in realistic or well-motivated settings
+- [ ] **Proof complete (no hand-waving)**: Each step in the proof is fully justified with no unexplained leaps
+- [ ] **Bound is tight**: The result includes a matching lower bound or discussion of tightness
+- [ ] **Proof technique appropriate**: The chosen proof method is well-suited to the problem structure
+- [ ] **Edge cases handled**: Degenerate or boundary cases are addressed within or following the main proof
+
+### Theory-Practice Gap Checklist
+
+- [ ] **Practical relevance discussed**: The authors articulate why the theoretical result matters in practice
+- [ ] **Gap acknowledged**: Differences between the theoretical setting and real-world conditions are noted
+- [ ] **Empirical validation where possible**: Experiments or examples are provided to support the theoretical claims
+- [ ] **Constants are reasonable**: Hidden constants in asymptotic results are estimated or discussed for practical applicability
+
+---
+
+## 3. Systems Papers
+
+### Benchmark Validity Checklist
+
+- [ ] **Workload representative**: Benchmarks reflect realistic or standard workloads for the target use case
+- [ ] **Comparison fair**: All systems are evaluated under equivalent configurations and resource constraints
+- [ ] **Scalability tested**: Performance is evaluated across a range of input sizes, data volumes, or concurrency levels
+- [ ] **Bottleneck analysis**: The paper identifies where the system spends time and what limits peak performance
+
+### Measurement Methodology Checklist
+
+- [ ] **Warm-up runs**: System is warmed up before measurements to eliminate cold-start artifacts
+- [ ] **Multiple trials**: Each measurement is repeated and results are aggregated (mean, median, or similar)
+- [ ] **Resource accounting**: CPU, memory, disk I/O, and network usage are tracked and reported where relevant
+- [ ] **End-to-end metrics**: Measurements include full pipeline overhead, not only the optimized component
+- [ ] **Latency distribution (p50/p99 not just mean)**: Tail latencies (e.g., p99) are reported alongside median to capture variability
+
+---
+
+## 4. Statistical Modeling Papers
+
+### Model Specification Checklist
+
+- [ ] **Generative process described**: The full data-generating model is stated (e.g., via plate diagram or formal notation)
+- [ ] **Prior choices justified**: Prior distributions are explained with rationale (informative, weakly informative, or non-informative)
+- [ ] **Likelihood appropriate**: The chosen likelihood function matches the data type and measurement process
+- [ ] **Identifiability**: The model parameters are identifiable from the data, or non-identifiability is acknowledged and handled
+
+### Inference Quality Checklist
+
+- [ ] **Convergence diagnostics (R-hat, ESS)**: R-hat values near 1.0 and sufficient effective sample sizes are reported for MCMC
+- [ ] **Posterior predictive checks**: Simulated data from the posterior is compared to observed data to assess model fit
+- [ ] **Sensitivity analysis**: Results are tested under alternative priors or model specifications to assess robustness
+- [ ] **Multiple chains**: MCMC inference uses at least 4 independent chains to detect convergence failures
+
+### Causal Claims Checklist (if applicable)
+
+- [ ] **Causal assumptions explicit (DAG)**: A directed acyclic graph or equivalent formalism is provided to encode causal structure
+- [ ] **No unmeasured confounders justified**: The authors argue why unmeasured confounding is unlikely or controlled for
+- [ ] **Intervention vs observation clear**: The paper distinguishes between observational associations and interventional effects
+- [ ] **Identification strategy**: A valid identification strategy (e.g., instrumental variables, regression discontinuity, front-door criterion) is described and justified

--- a/decision-packs/peer-review/opencode/skills/review-rubric/SKILL.md
+++ b/decision-packs/peer-review/opencode/skills/review-rubric/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: Review Rubric
+description: Review dimensions, scoring criteria, structural role scoping, and output format for peer review agents. Defines the 6 review dimensions, maps them to structural roles, and specifies the claim-grounded assessment format.
+---
+
+# Review Rubric
+
+This document is the primary reference for all reviewer agents. It defines what each reviewer evaluates, how assessments must be grounded in specific claims, what output format to produce, and which failure modes to avoid.
+
+---
+
+## 1. Review Dimensions
+
+Each dimension has a 1–5 integer score where 1 = very weak, 3 = acceptable, 5 = exceptional. Scores must always be accompanied by at least one cited claim ID.
+
+---
+
+### 1.1 Novelty
+
+**What it measures**: Whether the paper introduces genuinely new ideas, methods, datasets, frameworks, or perspectives that were not present or obvious in prior work.
+
+**Strong indicators**
+- Introduces a technique, model, or formulation not found in surveyed literature
+- Addresses a gap the related work section explicitly identifies and no prior work fills
+- Combines existing ideas in a non-obvious way with demonstrated synergistic effect
+- Opens a new line of inquiry or defines a new problem formulation
+- Produces a result that would surprise an expert reader familiar with the area
+
+**Weak indicators**
+- Incremental parameter tuning or minor architectural change with no conceptual contribution
+- Re-applies a known method to a new dataset without adaptation or insight
+- Claims of novelty are refuted or weakened by uncited prior work
+- Contribution is entirely engineering effort with no scientific originality
+- The paper itself hedges novelty claims heavily ("similar to X but…")
+
+**Common evaluation mistakes**
+1. Conflating novelty with correctness — a technically sound paper can have low novelty if it merely confirms known results.
+2. Penalizing empirical or engineering papers by applying theory-novelty standards that do not match the venue.
+3. Crediting novelty for claims the paper does not substantiate or demonstrate experimentally.
+
+---
+
+### 1.2 Rigor
+
+**What it measures**: Mathematical, statistical, and experimental correctness. Whether claims are derived, proven, or tested appropriately and conclusions are supported by the evidence presented.
+
+**Strong indicators**
+- Proofs are complete, lemmas are stated with full hypotheses, and assumptions are explicit
+- Statistical tests are appropriate for the data distribution; p-values or confidence intervals reported
+- Ablations isolate individual variables and baselines are fair, contemporaneous, and reproducible
+- Negative results and failure modes are reported alongside positive results
+- Mathematical notation is consistent throughout and key quantities are defined before use
+
+**Weak indicators**
+- Conclusions stated as certain when error bars overlap or statistical tests are absent
+- Key lemma missing a proof or proof sketch with hand-wavy steps
+- Baselines are outdated, cherry-picked, or evaluated under different conditions than the proposed method
+- Hyperparameter search performed only for the proposed method, not for baselines
+- Equations have undefined variables or dimensional inconsistencies
+
+**Common evaluation mistakes**
+1. Accepting an informal argument as a proof — "it is clear that" and "trivially follows" are not proofs.
+2. Overlooking that a p-value below 0.05 is not sufficient if multiple comparisons are made without correction.
+3. Penalizing the paper for a claimed result that is correct but uses non-standard notation the reviewer finds unfamiliar.
+
+---
+
+### 1.3 Clarity
+
+**What it measures**: Writing quality, logical organization, figure and table quality, and whether a competent reader in the field can follow the paper's argument without external assistance.
+
+**Strong indicators**
+- Problem statement and contributions are stated explicitly and early
+- Section structure matches the logical flow of the argument (motivation → method → experiments → analysis)
+- Figures are self-contained with descriptive captions; axes are labeled with units
+- Technical terms are defined at first use and used consistently
+- Related work situates the paper's position clearly relative to the cited work
+
+**Weak indicators**
+- Introduction does not distinguish the problem from adjacent problems
+- Methods section requires the reader to consult supplementary material to understand the core algorithm
+- Figures reuse acronyms that differ from main text, or axes lack labels
+- Tense, voice, or terminology shifts unexpectedly between sections
+- Key claims appear in abstract and conclusion but lack a corresponding methods or results section
+
+**Common evaluation mistakes**
+1. Penalizing non-native English phrasing while ignoring genuine structural clarity problems that affect understanding.
+2. Rating clarity purely on prose polish rather than on whether the technical argument is followable.
+3. Conflating clarity with correctness — a clearly written incorrect argument should score high on clarity and low on rigor.
+
+---
+
+### 1.4 Significance
+
+**What it measures**: Impact on the field if the paper is published. Whether the contribution moves forward the state of the art, enables new research directions, or matters to a meaningful audience.
+
+**Strong indicators**
+- Addresses a problem recognized as important or open in the community (e.g., cited as future work in multiple papers)
+- Results would change how practitioners choose methods or set benchmarks
+- Potential to be built upon: introduces formalism, dataset, or method reusable in other contexts
+- Scope is clearly defined and the contribution fully addresses that scope
+- The paper would be cited by work in adjacent subfields, not only the immediate niche
+
+**Weak indicators**
+- Addresses a synthetic or artificially narrow problem constructed to make the method look good
+- Gains over baselines are marginal and within measurement noise
+- Results hold only under narrow assumptions unlikely to generalize
+- Problem domain has a small, self-contained audience with limited cross-area impact
+- Contribution described only by comparison to direct predecessors with no broader framing
+
+**Common evaluation mistakes**
+1. Conflating significance with novelty — a paper can confirm or unify existing results in a way that is highly significant but not novel.
+2. Discounting significance because the reviewer's own subfield is not the target audience.
+3. Inflating significance because the method achieves a state-of-the-art number without considering whether the benchmark itself is meaningful.
+
+---
+
+### 1.5 Reproducibility
+
+**What it measures**: Whether an independent researcher could replicate the paper's core results using only the paper and any publicly released code or data, without contacting the authors.
+
+**Strong indicators**
+- All hyperparameters, random seeds, and hardware configurations are reported in the paper or supplementary
+- Training/evaluation splits, preprocessing steps, and data cleaning decisions are documented
+- Code or model weights are released with a permissive license and include a runnable example
+- Results vary across seeds and variance is reported; the best single-run result is not the only figure reported
+- The paper specifies which results from prior work are reproduced vs. taken from the original papers
+
+**Weak indicators**
+- Critical hyperparameters are omitted or described only vaguely ("we tuned X")
+- Dataset filtering or preprocessing steps are absent or inconsistent between text and code
+- Evaluation protocol differs subtly from described baselines in ways that favor the proposed method
+- Code is not released, or released code does not match the paper's described method
+- Compute requirements are not stated, making it impossible to judge practical reproducibility
+
+**Common evaluation mistakes**
+1. Accepting "code will be released upon acceptance" as satisfying reproducibility requirements.
+2. Treating reproducibility as binary — partial information disclosure (e.g., key hyperparameters listed but no code) should receive partial credit.
+3. Assuming a paper is reproducible because the method is simple; simplicity does not substitute for explicit documentation.
+
+---
+
+### 1.6 Related Work
+
+**What it measures**: Whether the paper fairly characterizes, compares against, and cites the relevant prior art, including work that may weaken or contextualize its own contribution.
+
+**Strong indicators**
+- All direct predecessors are cited and quantitatively compared where applicable
+- Work that partially achieves the same goal is acknowledged and the difference explained
+- The related work section identifies what problem the cited works leave unsolved
+- Papers from adjacent subfields that are relevant are included, not only work from the authors' own community
+- Limitations of cited methods are stated accurately and not overstated to inflate the perceived gap
+
+**Weak indicators**
+- Key competing methods are absent from the literature review and from experimental baselines
+- Related work is a citation list without synthesis or comparative analysis
+- Characterizations of prior work are inaccurate (e.g., claiming a method does not handle X when it does)
+- Self-citation rate is high relative to the coverage of the field
+- Work published after the submission deadline is cited selectively to favor the authors' claims
+
+**Common evaluation mistakes**
+1. Penalizing the paper for not citing work the reviewer happens to know if that work postdates the submission.
+2. Demanding citation of every tangentially related paper rather than judging whether the coverage is sufficient for the contribution being made.
+3. Conflating an incomplete related work section with dishonest related work — omission is usually a clarity/rigor issue, not misconduct.
+
+---
+
+## 2. Structural Role Scoping
+
+Each reviewer agent is assigned a structural role. Roles define which dimensions an agent is primarily responsible for and which dimensions it may comment on when evidence in those dimensions is directly encountered.
+
+| Role | Primary Dimensions | May Comment On |
+|---|---|---|
+| claim-verifier | Rigor, Reproducibility | Any claim in any dimension |
+| methodology-auditor | Rigor, Reproducibility | Significance (if method limits conclusions) |
+| novelty-assessor | Novelty, Related Work | Significance (if novelty is main contribution) |
+| clarity-evaluator | Clarity | Any dimension (if clarity affects understanding) |
+| significance-assessor | Significance | Novelty (relationship between novelty and significance) |
+
+**Interpretation rules**
+
+- An agent should only produce a dimensional score for its **Primary Dimensions**.
+- Commentary on "May Comment On" dimensions should be filed as an observation, not a score.
+- If a reviewer encounters a clear error in an out-of-scope dimension (e.g., a clarity-evaluator finds a mathematical contradiction), it should flag it as an observation and defer scoring to the appropriate role.
+- Agents must not score dimensions outside their primary or comment scope.
+
+---
+
+## 3. Claim Grounding Requirement
+
+Every assessment — whether a dimensional score, a strength, or a weakness — **must cite at least one specific claim ID** from the parsed paper. Ungrounded assertions are not acceptable review content.
+
+Claim IDs are assigned by the `parse-paper` tool and take the form `C<section>.<index>` (e.g., `C3.2`, `C5.1`).
+
+### DO
+
+```
+Rigor: 2/5
+The main theorem (C4.1) is stated without proof; the paper says "proof follows from
+standard arguments" but does not provide even a proof sketch. The experimental
+comparison in (C6.3) uses different evaluation metrics for the proposed method
+vs. baselines, which undermines the quantitative claims.
+```
+
+```
+Weakness: Reproducibility gap
+Hyperparameter table (C7.1) lists learning rate and batch size but omits the
+weight decay schedule, which the ablation (C7.4) identifies as the single most
+impactful hyperparameter. Without it, the result in Table 3 (C6.5) cannot be
+reproduced.
+```
+
+### DO NOT
+
+```
+Rigor: 2/5
+The experiments are not convincing and the proofs have gaps.
+```
+
+```
+Weakness: The paper is hard to reproduce.
+```
+
+These DO NOT examples are invalid because they contain no claim IDs. Any assessment filed without a claim ID will be treated as incomplete and excluded from consolidation.
+
+---
+
+## 4. Output Format
+
+Every reviewer agent must produce a `summary.md` file in its assigned output directory. The file must follow this exact structure.
+
+```markdown
+# Review: <Role Name>
+
+## Role
+<role-identifier>  <!-- e.g., novelty-assessor -->
+
+## Dimensional Assessments
+
+<!-- One entry per PRIMARY dimension for this role. -->
+
+### <Dimension Name>: <Score>/5
+
+<Prose justification. Minimum 2 sentences. Must cite at least one claim ID.>
+
+---
+
+<!-- Repeat for each primary dimension -->
+
+## Claim Evaluations
+
+| Claim ID | Verdict | Notes |
+|----------|---------|-------|
+| C<n>.<m> | Supported / Unsupported / Partial / Unverifiable | <one-line explanation> |
+
+<!-- Include ALL claims examined, not only those that fail. -->
+
+## Strengths
+
+- <Specific strength with claim ID> (C<n>.<m>)
+- <Specific strength with claim ID> (C<n>.<m>)
+<!-- Minimum 2 entries -->
+
+## Weaknesses
+
+- <Specific weakness with claim ID> (C<n>.<m>)
+- <Specific weakness with claim ID> (C<n>.<m>)
+<!-- Minimum 2 entries; if genuinely no weaknesses, explain why with a claim citation -->
+
+## Observations (Out-of-Scope)
+
+<!-- Optional section. Use only for observations in "May Comment On" dimensions or
+     cross-dimension flags. Do NOT assign scores here. -->
+
+- [<Dimension>] <Observation> (C<n>.<m>)
+
+## Confidence
+
+**Level**: High / Medium / Low
+
+**Rationale**: <1–3 sentences explaining confidence level. High = reviewer has clear
+expertise and claims are unambiguous. Low = outside reviewer's primary expertise or
+claims are difficult to verify without running code.>
+```
+
+**Mandatory fields**: Role, all primary dimensional assessments with scores, Claim Evaluations table (at least one row), Strengths (at least two entries), Weaknesses (at least two entries), Confidence.
+
+**Optional fields**: Observations (Out-of-Scope).
+
+---
+
+## 5. Anti-Patterns
+
+Reviewers must never exhibit the following behaviors. Violations cause invalid reviews that the consolidator will flag and exclude.
+
+### 5.1 Vague Praise
+**Never** write generic positive statements without evidence.
+
+Bad: "The paper is well-written and the experiments are comprehensive."
+Good: "Section 3 (C3.1–C3.4) presents the method with consistent notation and sufficient detail to follow the algorithm."
+
+---
+
+### 5.2 Score Without Evidence
+**Never** assign a dimensional score without at least one cited claim ID and an explanatory sentence.
+
+Bad: `Novelty: 4/5`
+Good: `Novelty: 4/5 — The proposed sparse attention kernel (C2.3) has not appeared in any cited or surveyed work, and the paper provides a formal efficiency bound (C4.1) distinguishing it from prior linear-attention variants.`
+
+---
+
+### 5.3 Conflating Dimensions
+**Never** penalize one dimension for a failure in another.
+
+Bad: Lowering Novelty because the writing is unclear.
+Good: Score Clarity low for the writing; score Novelty based solely on whether the idea is new.
+
+---
+
+### 5.4 Judging Missing Work
+**Never** penalize the paper for not doing additional work beyond its stated scope, unless the omission directly undermines a specific claim the paper makes.
+
+Bad: "The authors should also evaluate on dataset X."
+Good: "The paper claims generalization to out-of-distribution data (C5.2), but all experiments use in-distribution test splits (C6.1–C6.4), which does not support that claim."
+
+---
+
+### 5.5 Expertise Hallucination
+**Never** claim to have verified something you cannot actually verify from the paper text. If a claim requires running experiments, checking a proof in full formal detail, or consulting literature not in your context, mark the verdict as `Unverifiable` in the Claim Evaluations table and explain why.
+
+Bad: Marking a proof as `Supported` when only the statement was read.
+Good: Marking `Unverifiable` with note "Proof sketch references Lemma A.3 in supplementary; supplementary not provided."
+
+---
+
+### 5.6 Anchoring on Other Reviewers
+**Never** read or reference another reviewer agent's `summary.md` before completing your own. Reviews must be independent. The consolidator role is responsible for synthesizing across reviewers. Individual reviewers must produce their assessments solely from the parsed paper claims.

--- a/decision-packs/peer-review/opencode/tools/fetch-references.ts
+++ b/decision-packs/peer-review/opencode/tools/fetch-references.ts
@@ -1,0 +1,24 @@
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Fetch paper metadata and abstract from Semantic Scholar by title. Returns JSON with title, authors, year, venue, abstract, and citation count. Rate-limited to respect API limits.",
+
+  args: {
+    query: tool.schema.string().describe("Paper title or citation key to search for"),
+  },
+
+  async execute({ query }) {
+    const result = await Bun.$`python -c "
+from peer_review_lib.fetch_references import fetch_and_print
+fetch_and_print('${query}')
+"`.nothrow()
+    const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
+
+    if (result.exitCode !== 0) {
+      return `ERROR (exit code ${result.exitCode}):\n${stderr}\n\nStdout:\n${stdout}`
+    }
+
+    return stdout
+  },
+})

--- a/decision-packs/peer-review/opencode/tools/parse-paper.ts
+++ b/decision-packs/peer-review/opencode/tools/parse-paper.ts
@@ -1,0 +1,24 @@
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Parse a PDF or LaTeX paper into structured text with section boundaries, metadata, and citation keys. Use this FIRST on any paper before analysis.",
+
+  args: {
+    path: tool.schema.string().describe("Path to paper file (.pdf or .tex)"),
+  },
+
+  async execute({ path }) {
+    const result = await Bun.$`python -c "
+from peer_review_lib.parse_paper import parse_and_print
+parse_and_print('${path}')
+"`.nothrow()
+    const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
+
+    if (result.exitCode !== 0) {
+      return `ERROR (exit code ${result.exitCode}):\n${stderr}\n\nStdout:\n${stdout}`
+    }
+
+    return stdout
+  },
+})

--- a/docs/superpowers/plans/2026-04-09-peer-review-dpack.md
+++ b/docs/superpowers/plans/2026-04-09-peer-review-dpack.md
@@ -1,0 +1,2138 @@
+# Peer Review Decision Pack Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Decision Lab decision pack that simulates academic peer review using parallel structural reviewer agents, claim decomposition, and a reference knowledge base.
+
+**Architecture:** An orchestrator agent parses a paper, fans out decomposer and reference-analyst agents, then fans out 5 structural reviewer roles (claim-verifier, methodology-auditor, novelty-assessor, clarity-evaluator, significance-assessor) × N models. Orchestrator-mediated discussion rounds resolve disagreements. Output is a structured review report with conflict detection.
+
+**Tech Stack:** Python 3.11 (PyMuPDF for PDF parsing, httpx for Semantic Scholar API), TypeScript (OpenCode tool plugin format), Docker, dlab decision pack conventions.
+
+**Spec:** `docs/superpowers/specs/2026-04-09-peer-review-dpack-design.md`
+
+---
+
+## File Structure
+
+```
+decision-packs/peer-review/
+├── config.yaml                              # dpack config
+├── docker/
+│   ├── Dockerfile                           # Python 3.11-slim + PyMuPDF + httpx
+│   └── peer_review_lib/
+│       ├── __init__.py                      # Package exports
+│       ├── parse_paper.py                   # PDF/LaTeX → structured text
+│       └── fetch_references.py              # Semantic Scholar API client
+├── opencode/
+│   ├── opencode.json                        # Default agent + permissions
+│   ├── agents/
+│   │   ├── orchestrator.md                  # Area chair — 10-step workflow
+│   │   ├── decomposer.md                    # Claim extraction subagent
+│   │   ├── reference-analyst.md             # Reference KB builder subagent
+│   │   └── reviewer.md                      # Structural review subagent
+│   ├── tools/
+│   │   ├── parse-paper.ts                   # Calls parse_paper.py
+│   │   └── fetch-references.ts              # Calls fetch_references.py
+│   ├── skills/
+│   │   ├── review-rubric/SKILL.md           # Dimensions, criteria, output format
+│   │   ├── common-flaws/SKILL.md            # Paper weakness taxonomy
+│   │   └── methodology/SKILL.md             # Evaluation frameworks by paper type
+│   └── parallel_agents/
+│       ├── decomposer.yaml                  # 2 instances, Opus + Gemini
+│       ├── reference-analyst.yaml           # 2 instances, Opus + Gemini
+│       └── reviewer.yaml                    # Up to 15 instances, role × model
+```
+
+---
+
+## Task 1: Scaffold Decision Pack + Config Files
+
+**Files:**
+- Create: `decision-packs/peer-review/config.yaml`
+- Create: `decision-packs/peer-review/opencode/opencode.json`
+- Create: `decision-packs/peer-review/docker/Dockerfile`
+- Create: `decision-packs/peer-review/docker/peer_review_lib/__init__.py`
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p decision-packs/peer-review/docker/peer_review_lib
+mkdir -p decision-packs/peer-review/opencode/agents
+mkdir -p decision-packs/peer-review/opencode/tools
+mkdir -p decision-packs/peer-review/opencode/skills/review-rubric
+mkdir -p decision-packs/peer-review/opencode/skills/common-flaws
+mkdir -p decision-packs/peer-review/opencode/skills/methodology
+mkdir -p decision-packs/peer-review/opencode/parallel_agents
+```
+
+- [ ] **Step 2: Write config.yaml**
+
+```yaml
+name: peer-review
+description: Simulated academic peer review using parallel structural reviewers
+docker_image_name: dlab-peer-review
+default_model: anthropic/claude-opus-4-5
+requires_prompt: false
+```
+
+- [ ] **Step 3: Write opencode.json**
+
+```json
+{
+  "default_agent": "orchestrator",
+  "permission": {
+    "external_directory": { "*": "allow" }
+  }
+}
+```
+
+- [ ] **Step 4: Write Dockerfile**
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir \
+    PyMuPDF==1.25.3 \
+    pdfplumber==0.11.4 \
+    httpx==0.28.1
+
+COPY peer_review_lib /opt/peer_review_lib
+
+ENV PYTHONPATH="/opt"
+
+RUN python -c "import peer_review_lib; print('peer_review_lib import OK')"
+RUN python -c "import fitz; print('PyMuPDF import OK')"
+
+CMD ["/bin/bash"]
+```
+
+- [ ] **Step 5: Write peer_review_lib/__init__.py**
+
+```python
+"""
+Peer Review Library
+
+Modules:
+- parse_paper: PDF/LaTeX → structured text with section boundaries
+- fetch_references: Semantic Scholar API client for building reference KB
+"""
+
+__version__ = "0.1.0"
+
+from .parse_paper import parse_paper, parse_and_print
+from .fetch_references import fetch_reference, fetch_references_batch
+
+__all__ = [
+    "__version__",
+    "parse_paper",
+    "parse_and_print",
+    "fetch_reference",
+    "fetch_references_batch",
+]
+```
+
+- [ ] **Step 6: Verify structure matches dpack requirements**
+
+```bash
+# Verify dlab validates the structure (it checks for docker/, opencode/, config.yaml)
+cd /home/clsandoval/cs/decision-lab
+~/miniconda3/envs/dlab-testing/bin/python -c "
+from dlab.config import validate_config_structure
+validate_config_structure('decision-packs/peer-review')
+print('Structure valid')
+"
+```
+
+Expected: `Structure valid`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add decision-packs/peer-review/
+git commit -m "feat(peer-review): scaffold decision pack with config, Dockerfile, and package init"
+```
+
+---
+
+## Task 2: Paper Parsing Python Library
+
+**Files:**
+- Create: `decision-packs/peer-review/docker/peer_review_lib/parse_paper.py`
+
+- [ ] **Step 1: Write parse_paper.py**
+
+This module handles both PDF and LaTeX input. Two main functions:
+
+```python
+"""
+Paper parsing: PDF and LaTeX → structured text with section boundaries.
+
+Uses PyMuPDF (fitz) for PDF extraction and regex-based parsing for LaTeX.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import fitz  # PyMuPDF
+
+
+def _detect_format(path: str) -> str:
+    """Detect whether input is PDF or LaTeX based on extension."""
+    p = Path(path)
+    if p.suffix.lower() == ".tex":
+        return "latex"
+    if p.suffix.lower() == ".pdf":
+        return "pdf"
+    # Try reading first bytes to detect PDF magic
+    with open(path, "rb") as f:
+        header = f.read(5)
+    if header == b"%PDF-":
+        return "pdf"
+    return "latex"
+
+
+def _parse_pdf(path: str) -> dict[str, Any]:
+    """
+    Parse a PDF file into structured text.
+
+    Returns dict with keys: title, pages, source, citations, sections.
+    """
+    doc = fitz.open(path)
+    pages: list[str] = []
+    for page in doc:
+        pages.append(page.get_text())
+
+    full_text = "\n".join(pages)
+
+    # Extract title: first non-empty line from page 1, heuristic
+    first_page_lines = [
+        line.strip() for line in pages[0].split("\n") if line.strip()
+    ]
+    title = first_page_lines[0] if first_page_lines else "Unknown Title"
+
+    # Detect sections via common heading patterns
+    sections = _extract_sections_from_text(full_text)
+
+    # Extract citations: look for common patterns
+    citations = _extract_citations(full_text)
+
+    # Detect figures
+    figure_count = 0
+    for page in doc:
+        figure_count += len(page.get_images(full=True))
+
+    doc.close()
+
+    return {
+        "title": title,
+        "pages": len(pages),
+        "source": "PDF",
+        "figures_detected": figure_count,
+        "citations": citations,
+        "sections": sections,
+        "full_text": full_text,
+    }
+
+
+def _parse_latex(path: str) -> dict[str, Any]:
+    """
+    Parse a LaTeX file into structured text.
+
+    Returns dict with keys: title, pages, source, citations, sections.
+    """
+    text = Path(path).read_text(encoding="utf-8", errors="replace")
+
+    # Extract title
+    title_match = re.search(r"\\title\{([^}]+)\}", text)
+    title = title_match.group(1).strip() if title_match else "Unknown Title"
+
+    # Extract abstract
+    abstract_match = re.search(
+        r"\\begin\{abstract\}(.*?)\\end\{abstract\}", text, re.DOTALL
+    )
+    abstract = abstract_match.group(1).strip() if abstract_match else ""
+
+    # Extract sections
+    sections: list[dict[str, str]] = []
+    if abstract:
+        sections.append({"heading": "ABSTRACT", "text": abstract})
+
+    # Match \section{...}, \subsection{...}, etc.
+    section_pattern = re.compile(
+        r"\\(section|subsection|subsubsection)\{([^}]+)\}"
+    )
+    matches = list(section_pattern.finditer(text))
+
+    for i, match in enumerate(matches):
+        level = match.group(1)
+        heading = match.group(2).strip()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+        # Clean LaTeX commands from body (basic cleanup)
+        body = re.sub(r"\\[a-zA-Z]+\{([^}]*)\}", r"\1", body)
+        prefix = "" if level == "section" else "  " if level == "subsection" else "    "
+        sections.append({"heading": f"{prefix}{heading}", "text": body})
+
+    # Extract citations
+    cite_pattern = re.compile(r"\\cite[pt]?\{([^}]+)\}")
+    citation_keys: list[str] = []
+    for match in cite_pattern.finditer(text):
+        keys = match.group(1).split(",")
+        citation_keys.extend(k.strip() for k in keys)
+    citations = sorted(set(citation_keys))
+
+    return {
+        "title": title,
+        "pages": None,
+        "source": "LaTeX",
+        "figures_detected": text.count("\\begin{figure}"),
+        "citations": citations,
+        "sections": sections,
+        "full_text": text,
+    }
+
+
+def _extract_sections_from_text(text: str) -> list[dict[str, str]]:
+    """
+    Extract sections from raw text using heading patterns.
+
+    Handles patterns like:
+    - "1. Introduction"
+    - "1 Introduction"
+    - "Abstract"
+    - "INTRODUCTION"
+    - "2.1 Related Work"
+    """
+    # Common section heading patterns in academic papers
+    heading_pattern = re.compile(
+        r"^(?:"
+        r"(?:Abstract|ABSTRACT)|"  # Abstract
+        r"(?:\d+\.?\s+[A-Z][A-Za-z\s:&-]+)|"  # "1. Introduction" or "1 Introduction"
+        r"(?:\d+\.\d+\.?\s+[A-Z][A-Za-z\s:&-]+)|"  # "2.1 Related Work"
+        r"(?:[A-Z][A-Z\s:&-]{3,})"  # "INTRODUCTION", "RELATED WORK"
+        r")\s*$",
+        re.MULTILINE,
+    )
+
+    matches = list(heading_pattern.finditer(text))
+    if not matches:
+        return [{"heading": "FULL TEXT", "text": text}]
+
+    sections: list[dict[str, str]] = []
+    for i, match in enumerate(matches):
+        heading = match.group(0).strip()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+        sections.append({"heading": heading, "text": body})
+
+    return sections
+
+
+def _extract_citations(text: str) -> list[str]:
+    """
+    Extract citation references from text.
+
+    Handles patterns like:
+    - [1], [2, 3], [Smith et al., 2023]
+    - (Smith, 2023), (Smith & Jones, 2023)
+    - Smith et al. (2023)
+    """
+    citations: list[str] = []
+
+    # Bracketed numeric: [1], [2, 3, 4]
+    bracket_nums = re.findall(r"\[(\d+(?:\s*,\s*\d+)*)\]", text)
+    for match in bracket_nums:
+        nums = [n.strip() for n in match.split(",")]
+        citations.extend(nums)
+
+    # Author-year in brackets: [Smith et al., 2023]
+    bracket_author = re.findall(
+        r"\[([A-Z][a-z]+(?:\s+et\s+al\.?)?,?\s*\d{4}[a-z]?)\]", text
+    )
+    citations.extend(bracket_author)
+
+    # Parenthetical: (Smith, 2023), (Smith & Jones, 2023)
+    paren_author = re.findall(
+        r"\(([A-Z][a-z]+(?:\s+(?:&|and)\s+[A-Z][a-z]+)?,?\s*\d{4}[a-z]?)\)",
+        text,
+    )
+    citations.extend(paren_author)
+
+    return sorted(set(citations))
+
+
+def parse_paper(path: str) -> dict[str, Any]:
+    """
+    Parse a paper (PDF or LaTeX) into structured text.
+
+    Parameters
+    ----------
+    path : str
+        Path to the paper file (.pdf or .tex).
+
+    Returns
+    -------
+    dict[str, Any]
+        Keys: title, pages, source, figures_detected, citations, sections, full_text.
+        sections is a list of dicts with 'heading' and 'text' keys.
+    """
+    fmt = _detect_format(path)
+    if fmt == "pdf":
+        return _parse_pdf(path)
+    return _parse_latex(path)
+
+
+def parse_and_print(path: str) -> None:
+    """
+    Parse a paper and print structured output to stdout.
+
+    This is the entry point called by the parse-paper.ts tool.
+    """
+    result = parse_paper(path)
+
+    # Print metadata block
+    print("=== METADATA ===")
+    print(f"Title: {result['title']}")
+    if result["pages"] is not None:
+        print(f"Pages: {result['pages']}")
+    print(f"Source: {result['source']}")
+    print(f"Figures detected: {result['figures_detected']}")
+    print(f"Citations found: {len(result['citations'])}")
+    if result["citations"]:
+        print(f"Citation keys: {json.dumps(result['citations'])}")
+    print()
+
+    # Print sections
+    for section in result["sections"]:
+        heading = section["heading"]
+        text = section["text"]
+        print(f"=== {heading} ===")
+        print(text)
+        print()
+```
+
+- [ ] **Step 2: Verify parse_paper.py imports cleanly**
+
+```bash
+cd decision-packs/peer-review/docker
+python3 -c "
+import sys; sys.path.insert(0, '.')
+from peer_review_lib.parse_paper import parse_paper, parse_and_print
+print('parse_paper imports OK')
+"
+```
+
+Expected: `parse_paper imports OK` (may fail if PyMuPDF not installed locally — that's fine, it runs inside Docker)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add decision-packs/peer-review/docker/peer_review_lib/parse_paper.py
+git commit -m "feat(peer-review): add paper parsing library (PDF + LaTeX)"
+```
+
+---
+
+## Task 3: Reference Fetching Python Library
+
+**Files:**
+- Create: `decision-packs/peer-review/docker/peer_review_lib/fetch_references.py`
+
+- [ ] **Step 1: Write fetch_references.py**
+
+```python
+"""
+Semantic Scholar API client for fetching paper metadata and abstracts.
+
+Uses the Semantic Scholar Academic Graph API (free, no auth for basic usage).
+Rate limit: 100 requests per 5 minutes for unauthenticated access.
+"""
+
+import json
+import time
+from typing import Any
+
+import httpx
+
+
+BASE_URL = "https://api.semanticscholar.org/graph/v1"
+FIELDS = "title,authors,year,venue,abstract,citationCount,externalIds"
+# Conservative rate limiting: 1 request per 3 seconds
+REQUEST_INTERVAL = 3.0
+
+
+def fetch_reference(query: str, client: httpx.Client | None = None) -> dict[str, Any]:
+    """
+    Search Semantic Scholar for a paper by title or citation key.
+
+    Parameters
+    ----------
+    query : str
+        Paper title or citation key to search for.
+    client : httpx.Client | None
+        Optional reusable HTTP client. Creates one if not provided.
+
+    Returns
+    -------
+    dict[str, Any]
+        Paper metadata with keys: title, authors, year, venue, abstract,
+        citation_count, semantic_scholar_id, found.
+        If not found, returns dict with found=False and the query.
+    """
+    own_client = client is None
+    if own_client:
+        client = httpx.Client(timeout=15.0)
+
+    try:
+        resp = client.get(
+            f"{BASE_URL}/paper/search",
+            params={"query": query, "limit": 1, "fields": FIELDS},
+        )
+
+        if resp.status_code == 429:
+            # Rate limited — wait and retry once
+            time.sleep(10)
+            resp = client.get(
+                f"{BASE_URL}/paper/search",
+                params={"query": query, "limit": 1, "fields": FIELDS},
+            )
+
+        if resp.status_code != 200:
+            return {"found": False, "query": query, "error": f"HTTP {resp.status_code}"}
+
+        data = resp.json()
+        papers = data.get("data", [])
+        if not papers:
+            return {"found": False, "query": query, "error": "No results"}
+
+        paper = papers[0]
+        authors = [
+            a.get("name", "Unknown") for a in (paper.get("authors") or [])
+        ]
+
+        return {
+            "found": True,
+            "query": query,
+            "title": paper.get("title", ""),
+            "authors": authors,
+            "year": paper.get("year"),
+            "venue": paper.get("venue", ""),
+            "abstract": paper.get("abstract", ""),
+            "citation_count": paper.get("citationCount", 0),
+            "semantic_scholar_id": paper.get("paperId", ""),
+            "external_ids": paper.get("externalIds", {}),
+        }
+    finally:
+        if own_client:
+            client.close()
+
+
+def fetch_references_batch(queries: list[str]) -> list[dict[str, Any]]:
+    """
+    Fetch multiple papers from Semantic Scholar with rate limiting.
+
+    Parameters
+    ----------
+    queries : list[str]
+        List of paper titles or citation keys.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of paper metadata dicts (same format as fetch_reference).
+    """
+    results: list[dict[str, Any]] = []
+    with httpx.Client(timeout=15.0) as client:
+        for i, query in enumerate(queries):
+            if i > 0:
+                time.sleep(REQUEST_INTERVAL)
+            result = fetch_reference(query, client=client)
+            results.append(result)
+            status = "found" if result["found"] else "not found"
+            print(f"[{i + 1}/{len(queries)}] {query[:60]}... → {status}")
+    return results
+
+
+def fetch_and_print(query: str) -> None:
+    """
+    Fetch a single reference and print structured output.
+
+    This is the entry point called by the fetch-references.ts tool.
+    """
+    result = fetch_reference(query)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+```
+
+- [ ] **Step 2: Verify fetch_references.py imports cleanly**
+
+```bash
+cd decision-packs/peer-review/docker
+python3 -c "
+import sys; sys.path.insert(0, '.')
+from peer_review_lib.fetch_references import fetch_reference, fetch_references_batch
+print('fetch_references imports OK')
+"
+```
+
+Expected: `fetch_references imports OK` (may fail if httpx not installed locally — fine, runs in Docker)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add decision-packs/peer-review/docker/peer_review_lib/fetch_references.py
+git commit -m "feat(peer-review): add Semantic Scholar reference fetching library"
+```
+
+---
+
+## Task 4: TypeScript Tools
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/tools/parse-paper.ts`
+- Create: `decision-packs/peer-review/opencode/tools/fetch-references.ts`
+
+- [ ] **Step 1: Write parse-paper.ts**
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Parse a PDF or LaTeX paper into structured text with section boundaries, metadata, and citation keys. Use this FIRST on any paper before analysis.",
+
+  args: {
+    path: tool.schema.string().describe("Path to paper file (.pdf or .tex)"),
+  },
+
+  async execute({ path }) {
+    const result = await Bun.$`python -c "
+from peer_review_lib.parse_paper import parse_and_print
+parse_and_print('${path}')
+"`.nothrow()
+    const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
+
+    if (result.exitCode !== 0) {
+      return `ERROR (exit code ${result.exitCode}):\n${stderr}\n\nStdout:\n${stdout}`
+    }
+
+    return stdout
+  },
+})
+```
+
+- [ ] **Step 2: Write fetch-references.ts**
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Fetch paper metadata and abstract from Semantic Scholar by title. Returns JSON with title, authors, year, venue, abstract, and citation count. Rate-limited to respect API limits.",
+
+  args: {
+    query: tool.schema.string().describe("Paper title or citation key to search for"),
+  },
+
+  async execute({ query }) {
+    const result = await Bun.$`python -c "
+from peer_review_lib.fetch_references import fetch_and_print
+fetch_and_print('${query}')
+"`.nothrow()
+    const stdout = result.stdout.toString()
+    const stderr = result.stderr.toString()
+
+    if (result.exitCode !== 0) {
+      return `ERROR (exit code ${result.exitCode}):\n${stderr}\n\nStdout:\n${stdout}`
+    }
+
+    return stdout
+  },
+})
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/tools/
+git commit -m "feat(peer-review): add parse-paper and fetch-references tools"
+```
+
+---
+
+## Task 5: Skills — Review Rubric
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/skills/review-rubric/SKILL.md`
+
+- [ ] **Step 1: Write review-rubric/SKILL.md**
+
+```markdown
+---
+name: Review Rubric
+description: Review dimensions, scoring criteria, structural role scoping, and output format for peer review agents. Defines the 6 review dimensions, maps them to structural roles, and specifies the claim-grounded assessment format.
+---
+
+# Peer Review Rubric
+
+## Review Dimensions
+
+### 1. Novelty
+
+**What it measures:** Does this paper present new ideas, methods, perspectives, or combinations thereof?
+
+**Strong novelty indicators:**
+- New problem formulation that reframes an existing challenge
+- Novel method with theoretical or empirical justification for why it works
+- Surprising empirical finding that challenges conventional wisdom
+- New dataset or benchmark that enables previously impossible comparisons
+
+**Weak novelty indicators:**
+- Incremental parameter changes to existing methods
+- Applying an existing method to a slightly different domain without new insight
+- Combining known techniques without understanding WHY the combination helps
+
+**Common evaluation mistakes:**
+- Penalizing a paper for not being novel in a dimension it doesn't claim to be novel in
+- Confusing "I haven't seen this" with "this is novel" — check the related work
+- Treating engineering contributions as inherently less novel than theoretical ones
+
+### 2. Rigor
+
+**What it measures:** Are the mathematical, statistical, and experimental claims correct?
+
+**Strong rigor indicators:**
+- Proofs are complete, with all assumptions stated
+- Experiments control for confounds with appropriate baselines
+- Statistical tests are appropriate for the data and claims
+- Error bars, confidence intervals, or credible intervals are reported
+- Ablation studies isolate the contribution of each component
+
+**Weak rigor indicators:**
+- Claims based on single runs without variance reporting
+- Inappropriate statistical tests (e.g., t-test on non-normal data)
+- Missing baselines or unfair baseline comparisons
+- Proofs with unstated assumptions or hand-waved steps
+
+**Common evaluation mistakes:**
+- Demanding more rigor than the venue typically requires
+- Ignoring correct but unconventional statistical approaches
+- Conflating "different from what I would do" with "wrong"
+
+### 3. Clarity
+
+**What it measures:** Can a competent reader understand what was done and why?
+
+**Strong clarity indicators:**
+- Clear problem statement in first two pages
+- Notation is consistent throughout
+- Figures are self-contained (readable without main text)
+- Algorithm boxes or pseudocode for complex procedures
+- Related work is organized thematically, not just listed
+
+**Weak clarity indicators:**
+- Key definitions buried in appendix
+- Inconsistent notation (same symbol means different things)
+- Figures require the caption AND main text to interpret
+- Wall-of-text paragraphs without structure
+
+**Common evaluation mistakes:**
+- Penalizing dense writing that is actually precise
+- Conflating "unfamiliar to me" with "unclear"
+- Over-weighting formatting issues vs content clarity
+
+### 4. Significance
+
+**What it measures:** If the claims are true, how much does this matter?
+
+**Strong significance indicators:**
+- Addresses a problem many researchers or practitioners care about
+- Results change how people should think about or approach a problem
+- Enables new research directions or applications
+- Practical impact is clear and immediate
+
+**Weak significance indicators:**
+- Marginal improvement on a saturated benchmark
+- Problem is artificial or only relevant to the authors
+- Results are theoretically interesting but practically irrelevant (or vice versa)
+
+**Common evaluation mistakes:**
+- Equating significance with performance improvement on benchmarks
+- Dismissing foundational work because it doesn't have immediate applications
+- Penalizing papers for not solving a bigger problem than they claim to solve
+
+### 5. Reproducibility
+
+**What it measures:** Could an independent researcher replicate the results?
+
+**Strong reproducibility indicators:**
+- Code is released (or promised)
+- All hyperparameters, random seeds, and hardware specs reported
+- Dataset is publicly available or creation process is described
+- Training procedures are described in sufficient detail
+- Compute budget is reported
+
+**Weak reproducibility indicators:**
+- "Details in supplementary" but supplementary is incomplete
+- Key implementation details described vaguely ("we tuned learning rate")
+- Proprietary data with no synthetic alternative described
+- Missing information about compute requirements
+
+**Common evaluation mistakes:**
+- Requiring code release for theoretical papers
+- Treating "not yet released" as "will never be released"
+- Over-penalizing papers that use proprietary data when the method is clearly described
+
+### 6. Related Work
+
+**What it measures:** Is prior work fairly cited and compared against?
+
+**Strong related work indicators:**
+- Key prior work is cited AND discussed (not just listed)
+- Differences from most similar work are clearly articulated
+- Fair comparison: prior work is described accurately, not strawmanned
+- Missing citations are understandable (very recent, different subfield)
+
+**Weak related work indicators:**
+- Important prior work is missing entirely
+- Prior work is cited but mischaracterized
+- "Our method is different" without explaining HOW
+- Only self-citations or citations from one research group
+
+**Common evaluation mistakes:**
+- Demanding citation of every tangentially related paper
+- Penalizing for missing a paper published after submission
+- Expecting deep discussion of papers from very different subfields
+
+## Structural Role Scoping
+
+Each structural role covers specific dimensions. Stay within your assigned scope.
+
+| Role | Primary Dimensions | May Comment On |
+|------|-------------------|----------------|
+| claim-verifier | Rigor, Reproducibility | Any claim in any dimension |
+| methodology-auditor | Rigor, Reproducibility | Significance (if method limits conclusions) |
+| novelty-assessor | Novelty, Related Work | Significance (if novelty is the main contribution) |
+| clarity-evaluator | Clarity | Any dimension (if clarity affects understanding) |
+| significance-assessor | Significance | Novelty (relationship between novelty and significance) |
+
+## Claim Grounding Requirement
+
+**Every assessment MUST cite specific claim IDs from the claims index.**
+
+DO:
+- "Claim 14 (convergence bound in Lemma 3) is unsupported because Assumption 2 is violated when..."
+- "Claims 7-9 (experimental results on benchmark X) are well-supported by the ablation in Table 3"
+
+DO NOT:
+- "The paper has some issues with rigor" (no specific claims cited)
+- "The experiments seem weak" (which experiments? which claims?)
+- "This is a nice paper" (ungrounded praise is as bad as ungrounded criticism)
+
+## Output Format
+
+Every reviewer instance MUST write `summary.md` with this structure:
+
+```markdown
+## Role
+- Assigned role: [role name]
+- Dimensions in scope: [list]
+
+## Dimensional Assessments
+### [Dimension Name]
+- Assessment: [free-text evaluation]
+- Supporting claims: [claim IDs with brief reasoning]
+- References consulted: [files from reference_kb/ if any]
+
+## Claim Evaluations
+| Claim ID | Verdict | Reasoning |
+|----------|---------|-----------|
+| claim_001 | supported | [brief reasoning] |
+| claim_014 | unsupported | [brief reasoning] |
+
+## Strengths
+- [Strength grounded in claim IDs]
+
+## Weaknesses
+- [Weakness grounded in claim IDs]
+
+## Confidence
+- [Dimension]: [confident/moderate/uncertain] — [why]
+```
+
+## Anti-Patterns
+
+NEVER do these:
+
+- **Vague praise**: "This is an interesting paper" — say WHAT is interesting and cite the claim
+- **Score without evidence**: Every assessment must trace to claims
+- **Conflating dimensions**: Novelty and significance are different things. A paper can be novel but insignificant, or significant but not novel.
+- **Judging missing work**: Don't criticize a paper for not doing something it never claimed to do. Evaluate what IS claimed.
+- **Expertise hallucination**: If a claim is outside your knowledge, say "I cannot confidently evaluate Claim N because it requires expertise in [domain]." Do NOT fabricate an assessment.
+- **Anchoring on other reviewers**: In discussion rounds, form your own assessment first, THEN respond to others. Don't lead with "I agree with Reviewer X."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/skills/review-rubric/
+git commit -m "feat(peer-review): add review rubric skill with dimensions, scoping, and output format"
+```
+
+---
+
+## Task 6: Skills — Common Flaws
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/skills/common-flaws/SKILL.md`
+
+- [ ] **Step 1: Write common-flaws/SKILL.md**
+
+```markdown
+---
+name: Common Flaws
+description: Taxonomy of recurring academic paper weaknesses organized by category. Includes detection methods and severity levels for claim verification and decomposition agents.
+---
+
+# Common Paper Flaws Taxonomy
+
+Use this as a reference when extracting claims (decomposer) or evaluating them (claim-verifier). Each flaw has a detection method — use it as a checklist, not as a script.
+
+## Claims Flaws
+
+### Overclaiming
+- **Definition**: Stated conclusions are stronger than what the evidence supports
+- **Detection**: Compare the language in the abstract/conclusion with the actual results. Look for "we show" or "we prove" when the evidence is "we observe" or "our results suggest"
+- **Example**: "Our method achieves state-of-the-art" when it beats 2 of 5 baselines
+- **Severity**: Major
+
+### Unstated Assumptions
+- **Definition**: The argument relies on assumptions that are not made explicit
+- **Detection**: For each claim, ask "under what conditions is this true?" If the paper doesn't answer, the assumption is unstated
+- **Example**: A causal claim that assumes no unmeasured confounders without stating this
+- **Severity**: Major (if assumption is likely violated), Minor (if assumption is standard)
+
+### Circular Reasoning
+- **Definition**: The conclusion is assumed in the premises
+- **Detection**: Trace the logical chain from assumptions to conclusions. If any step uses the conclusion as input, it's circular
+- **Example**: Defining a "good" model as one that scores high on the proposed metric, then showing the proposed model scores high
+- **Severity**: Critical
+
+### Correlation as Causation
+- **Definition**: Causal language used for correlational evidence
+- **Detection**: Look for "causes", "leads to", "results in" when the methodology is observational
+- **Example**: "Using technique X leads to better performance" from a non-controlled comparison
+- **Severity**: Major
+
+## Experimental Flaws
+
+### Missing Ablation
+- **Definition**: A multi-component system is evaluated only as a whole
+- **Detection**: Count the novel components. If >1 and no ablation table, this is missing
+- **Example**: A model with 3 new modules evaluated only as a complete system
+- **Severity**: Major
+
+### Unfair Baselines
+- **Definition**: Baselines are not given equivalent resources or tuning
+- **Detection**: Check if baselines use the same data, compute budget, and hyperparameter tuning. Check if baseline implementations are original or re-implemented (re-implementations are often weaker)
+- **Example**: Comparing a heavily tuned new model against default-hyperparameter baselines
+- **Severity**: Major
+
+### Cherry-Picked Metrics
+- **Definition**: Reporting only metrics where the proposed method wins
+- **Detection**: Check if standard metrics for the task are all reported. Look for unusual or custom metrics
+- **Example**: Reporting F1 but not precision/recall when the method trades one for the other
+- **Severity**: Major
+
+### Test Set Leakage
+- **Definition**: Information from the test set influenced model development
+- **Detection**: Check the evaluation protocol. Is the test set truly held out? Were hyperparameters tuned on test data?
+- **Example**: "We selected the best checkpoint based on test performance"
+- **Severity**: Critical
+
+### Inadequate Error Bars
+- **Definition**: Variance of results is not reported
+- **Detection**: Check if results include standard deviations, confidence intervals, or are averaged over multiple runs
+- **Example**: Single-run results presented as definitive
+- **Severity**: Minor (if trends are large), Major (if differences are small)
+
+### Missing Significance Tests
+- **Definition**: Statistical significance of differences is not tested
+- **Detection**: When two methods are compared, is the difference statistically tested?
+- **Example**: "Method A achieves 85.2 vs Method B at 84.9" with no significance test
+- **Severity**: Minor (if gap is large), Major (if gap is small)
+
+## Presentation Flaws
+
+### Buried Key Results
+- **Definition**: The most important findings are not prominently presented
+- **Detection**: Can you find the main result within the first 2 pages? Is it in the abstract?
+- **Example**: The primary contribution is in Table 7 of the appendix
+- **Severity**: Minor
+
+### Misleading Figures
+- **Definition**: Figures visually exaggerate or obscure patterns
+- **Detection**: Check axis scales (truncated?), check if error bars are included, check if the visual impression matches the numbers
+- **Example**: Y-axis starting at 90% to make a 91% vs 92% difference look dramatic
+- **Severity**: Major
+
+### Inconsistent Notation
+- **Definition**: The same symbol or term means different things in different places
+- **Detection**: Track symbol definitions across sections. Flag any symbol used before definition or redefined
+- **Example**: "x" meaning input features in Section 3 and output predictions in Section 4
+- **Severity**: Minor
+
+## Related Work Flaws
+
+### Missing Key References
+- **Definition**: Important prior work is not cited
+- **Detection**: Cross-reference with the reference_kb/ analysis. Check Semantic Scholar for highly-cited papers on the same topic
+- **Example**: Not citing the paper that introduced the technique being extended
+- **Severity**: Major
+
+### Strawman Descriptions
+- **Definition**: Prior work is described inaccurately to make the comparison favorable
+- **Detection**: Compare the paper's description of prior work with the actual abstracts in reference_kb/
+- **Example**: "Prior method X cannot handle Y" when X's paper explicitly addresses Y
+- **Severity**: Major
+
+### Citing Without Comparing
+- **Definition**: Related work is listed but never actually compared against
+- **Detection**: Check if cited methods appear in the experimental comparison
+- **Example**: "Related work includes [1, 2, 3, 4, 5]" with none appearing in experiments
+- **Severity**: Minor (for tangentially related work), Major (for directly competing methods)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/skills/common-flaws/
+git commit -m "feat(peer-review): add common flaws taxonomy skill"
+```
+
+---
+
+## Task 7: Skills — Methodology
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/skills/methodology/SKILL.md`
+
+- [ ] **Step 1: Write methodology/SKILL.md**
+
+```markdown
+---
+name: Methodology Evaluation
+description: Evaluation frameworks for different paper types (empirical ML, theoretical, systems, statistical modeling). Provides checklists for methodology auditors and decomposer agents.
+---
+
+# Methodology Evaluation Frameworks
+
+Use the appropriate framework based on the paper type. Most papers are primarily one type but may have elements of others. Evaluate using the primary type's framework, noting where other frameworks are relevant.
+
+## Empirical ML Papers
+
+Papers that propose or evaluate methods using experiments on datasets.
+
+### Dataset & Evaluation Checklist
+
+- [ ] **Data splits described**: Train/val/test split ratios and method (random, temporal, stratified)
+- [ ] **No test leakage**: Test set genuinely held out during all development
+- [ ] **Dataset size adequate**: Sufficient examples for the complexity of the model
+- [ ] **Dataset bias acknowledged**: Known biases or limitations of the dataset discussed
+- [ ] **Evaluation metrics justified**: Why these metrics? Are they standard for this task?
+- [ ] **Multiple metrics reported**: Not just the one where the method wins
+
+### Experimental Design Checklist
+
+- [ ] **Baselines are fair**: Same data, comparable compute, tuned hyperparameters
+- [ ] **Baselines are relevant**: Include current SOTA and simple baselines
+- [ ] **Ablation study**: Each novel component evaluated independently
+- [ ] **Variance reported**: Multiple runs with different seeds, std reported
+- [ ] **Statistical significance**: Differences tested when margins are small
+- [ ] **Compute budget reported**: GPU hours, hardware specs, training time
+
+### Reproducibility Checklist
+
+- [ ] **Hyperparameters listed**: All hyperparameters with final values
+- [ ] **Architecture details complete**: Someone could reimplement from the paper
+- [ ] **Training procedure described**: Optimizer, learning rate schedule, early stopping criteria
+- [ ] **Code availability**: Released or promised, with timeline
+- [ ] **Random seeds reported**: For reproducible runs
+
+## Theoretical Papers
+
+Papers that prove properties, derive bounds, or establish theoretical frameworks.
+
+### Proof Quality Checklist
+
+- [ ] **All assumptions stated**: Every assumption the proof relies on is explicit
+- [ ] **Assumptions are reasonable**: Assumptions hold in realistic settings
+- [ ] **Proof is complete**: No hand-waved steps ("it can be shown that...")
+- [ ] **Bound is tight**: Is there a matching lower bound or construction showing tightness?
+- [ ] **Proof technique is appropriate**: Standard techniques applied correctly
+- [ ] **Edge cases handled**: Boundary conditions, degenerate cases addressed
+
+### Theory-Practice Gap Checklist
+
+- [ ] **Practical relevance discussed**: Does the theory apply to real systems?
+- [ ] **Gap acknowledged**: If assumptions are idealized, this is stated
+- [ ] **Empirical validation**: Theory predictions verified experimentally where possible
+- [ ] **Constants are reasonable**: O-notation hides constants — are they practical?
+
+## Systems Papers
+
+Papers that build and evaluate software/hardware systems.
+
+### Benchmark Validity Checklist
+
+- [ ] **Workload is representative**: Benchmarks reflect real usage patterns
+- [ ] **Comparison is fair**: Systems compared under equivalent conditions
+- [ ] **Scalability tested**: Performance at multiple scales, not just one
+- [ ] **Bottleneck analysis**: Where does the system spend time? Why?
+
+### Measurement Methodology Checklist
+
+- [ ] **Warm-up runs**: System reaches steady state before measurement
+- [ ] **Multiple trials**: Variance across runs reported
+- [ ] **Resource accounting**: CPU, memory, network, disk all measured
+- [ ] **End-to-end metrics**: Not just microbenchmarks that miss system effects
+- [ ] **Latency distribution**: p50, p99, not just mean (means hide tail latency)
+
+## Statistical Modeling Papers
+
+Papers that propose or apply statistical/probabilistic models.
+
+### Model Specification Checklist
+
+- [ ] **Generative process described**: Full probabilistic model written out
+- [ ] **Prior choices justified**: Why these priors? Sensitivity to prior choice discussed?
+- [ ] **Likelihood appropriate**: Does the likelihood match the data generating process?
+- [ ] **Identifiability**: Can the parameters be estimated from the data?
+
+### Inference Quality Checklist
+
+- [ ] **Convergence diagnostics**: R-hat, ESS, trace plots reported
+- [ ] **Posterior predictive checks**: Model predictions compared to observed data
+- [ ] **Sensitivity analysis**: Results robust to reasonable prior changes?
+- [ ] **Multiple chains**: Not just one MCMC chain
+
+### Causal Claims Checklist (if applicable)
+
+- [ ] **Causal assumptions explicit**: DAG or structural equations provided
+- [ ] **No unmeasured confounders justified**: Why is this reasonable?
+- [ ] **Intervention vs observation**: Clear about what is manipulated vs observed
+- [ ] **Identification strategy**: How are causal effects identified from observational data?
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/skills/methodology/
+git commit -m "feat(peer-review): add methodology evaluation frameworks skill"
+```
+
+---
+
+## Task 8: Parallel Agent Configs
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/parallel_agents/decomposer.yaml`
+- Create: `decision-packs/peer-review/opencode/parallel_agents/reference-analyst.yaml`
+- Create: `decision-packs/peer-review/opencode/parallel_agents/reviewer.yaml`
+
+- [ ] **Step 1: Write decomposer.yaml**
+
+```yaml
+name: decomposer
+description: "Extract atomic claims from paper with different models"
+timeout_minutes: 30
+failure_behavior: continue
+
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 3
+
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  ---
+
+  Write summary.md with your results:
+
+  ## Claim Count
+  - Total claims extracted
+  - By type: empirical, methodological, novelty, scope
+
+  ## Claims Index
+  For each claim:
+  - ID, text, type, section, evidence strength
+  - Dependencies on other claims
+
+  ## Parsing Issues
+  - Any sections that were unclear or hard to decompose
+
+  ---
+
+  Also write claims_index.json with the following structure:
+
+  ```json
+  {
+    "claims": [
+      {
+        "id": "claim_001",
+        "text": "The exact claim text from the paper",
+        "type": "empirical",
+        "section": "4.2 Experiments",
+        "evidence_strength": "supported",
+        "dependencies": ["claim_003"],
+        "reasoning": "Brief note on why this classification"
+      }
+    ]
+  }
+  ```
+
+summarizer_prompt: |
+  You are a consolidator agent with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Also read the claims_index.json files from each instance directory.
+
+  Create a consolidated claim index:
+  1. Deduplicate claims found by both models (match by content, not ID)
+  2. Flag claims found by only one model (mark provenance)
+  3. Note any classification disagreements (type, evidence_strength)
+  4. Produce a merged claims_index.json with deduplicated, renumbered claim IDs
+
+  Write both summary.md (human-readable comparison) and claims_index.json (canonical merged index).
+
+  Present facts only - do NOT resolve disagreements.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"
+```
+
+- [ ] **Step 2: Write reference-analyst.yaml**
+
+```yaml
+name: reference-analyst
+description: "Build reference knowledge base from cited papers"
+timeout_minutes: 30
+failure_behavior: continue
+
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 3
+
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  ---
+
+  Write summary.md with your results:
+
+  ## Reference Stats
+  - Total citations in paper
+  - Successfully fetched from Semantic Scholar
+  - Not found
+
+  ## Reference KB
+  - Path to reference_kb/ directory
+  - Number of paper files written
+
+  ## Key Findings
+  - Mischaracterizations found (list each with evidence)
+  - Contradictions identified (list each with evidence)
+  - Missing key references (list each with reasoning)
+  - Citation pattern observations
+
+  ---
+
+  Also write the full reference_kb/ directory:
+
+  reference_kb/
+  ├── index.md              (citation list with found/not-found status)
+  ├── papers/
+  │   ├── ref_001.md        (one file per cited paper)
+  │   └── ...
+  └── analysis.md           (mischaracterizations, contradictions, missing refs)
+
+  Each paper file in papers/ should contain:
+  - Title, authors, venue, year, citation count
+  - Abstract
+  - How the reviewed paper cites it (quote the relevant text)
+  - Characterization accuracy: accurate / inaccurate / partial (with reasoning)
+
+summarizer_prompt: |
+  You are a consolidator agent with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Also read the reference_kb/ directories from each instance.
+
+  Compare the reference analyses:
+  1. Did both analysts find the same mischaracterizations?
+  2. Do they agree on missing references?
+  3. Any contradictions one caught that the other missed?
+
+  Merge into a consolidated reference_kb/ directory and analysis.md
+  in your output directory. The orchestrator will copy this to the
+  main workspace for downstream agents.
+
+  Present facts only - do NOT resolve disagreements.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"
+```
+
+- [ ] **Step 3: Write reviewer.yaml**
+
+```yaml
+name: reviewer
+description: "Run structural review roles in parallel across models"
+timeout_minutes: 60
+failure_behavior: continue
+
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 15
+
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  ---
+
+  Write summary.md with your results:
+
+  ## Role
+  - Your assigned structural role
+  - Dimensions in your scope
+
+  ## Dimensional Assessments
+  For each review dimension in your scope:
+  - Free-text assessment
+  - Key claims supporting your assessment (cite claim IDs)
+  - References consulted from reference_kb/ (if any)
+
+  ## Claim Evaluations
+  For each claim you evaluated:
+  - Claim ID
+  - Verdict: supported / unsupported / unclear
+  - Reasoning (cite evidence)
+  - Reference from reference_kb/ if applicable
+
+  ## Strengths
+  - Grounded in specific claim IDs
+
+  ## Weaknesses
+  - Grounded in specific claim IDs
+
+  ## Confidence
+  - Per-dimension: confident / moderate / uncertain — with reasoning
+
+summarizer_prompt: |
+  You are a review consolidator with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Create a consolidated review comparison:
+  1. Per-dimension comparison across all reviewers
+  2. Claims where reviewers disagree (list claim IDs and verdicts)
+  3. Same-role/different-model agreements and disagreements
+  4. Cross-role tensions (e.g., claim-verifier vs methodology-auditor)
+  5. Reference-grounded disagreements
+
+  Present facts only - do NOT make a recommendation.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/parallel_agents/
+git commit -m "feat(peer-review): add parallel agent configs for decomposer, reference-analyst, reviewer"
+```
+
+---
+
+## Task 9: Subagent Definitions — Decomposer and Reference Analyst
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/agents/decomposer.md`
+- Create: `decision-packs/peer-review/opencode/agents/reference-analyst.md`
+
+- [ ] **Step 1: Write decomposer.md**
+
+````markdown
+---
+description: Extracts atomic claims and maps them to paper sections
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+  parse-paper: true
+skills:
+  - common-flaws
+  - methodology
+---
+
+# Claim Decomposition Agent
+
+You are a claim extraction specialist. Your job is to read a parsed academic paper and extract every atomic claim, classify it, map it to the paper's structure, and assess its evidence strength.
+
+## Your Task
+
+1. Read the paper text provided in your prompt
+2. Extract every atomic claim (see Claim Types below)
+3. Classify each claim by type
+4. Map each claim to the paper section it appears in
+5. Identify dependencies between claims
+6. Assess evidence strength for each claim
+7. Write `claims_index.json` and `summary.md`
+
+## What Is an Atomic Claim?
+
+An atomic claim is a single, verifiable assertion. Decompose compound statements into individual claims.
+
+**Compound (decompose this):**
+> "Our method achieves state-of-the-art accuracy on CIFAR-10 and is 3x faster than the baseline."
+
+**Atomic (into these):**
+> Claim A: "Our method achieves state-of-the-art accuracy on CIFAR-10"
+> Claim B: "Our method is 3x faster than the baseline"
+
+## Claim Types
+
+- **empirical**: Assertions about experimental results, measurements, or observations. "We achieve 95% accuracy." "Training takes 2 hours on a single GPU."
+- **methodological**: Assertions about how something works or why it works. "The attention mechanism allows the model to focus on relevant features." "Our loss function is convex."
+- **novelty**: Assertions about what is new. "To our knowledge, this is the first method to..." "Unlike prior work, we..."
+- **scope**: Assertions about limitations or applicability. "This approach is limited to supervised settings." "Our results hold for datasets with >1000 samples."
+
+## Evidence Strength
+
+- **proven**: Formal proof provided (theorems, lemmas with complete proofs)
+- **supported**: Empirical evidence or strong argument provided (experiments, ablations, citations to established results)
+- **asserted**: Stated without direct evidence in this paper (may be common knowledge or may be unsupported)
+
+## Dependency Tracking
+
+If Claim B relies on Claim A being true, record this dependency. Common patterns:
+- "Given our convergence result (Claim A), the method produces valid estimates (Claim B)"
+- Experimental claims that depend on methodological claims being correct
+- Novelty claims that depend on the related work characterization being accurate
+
+## CRITICAL: NEVER FABRICATE
+
+If a section is unclear or you cannot confidently extract a claim, mark it as unclear in your output. Do NOT invent claims that aren't in the paper.
+
+## Working Directory Rules
+
+- Read data from `data/` (relative path)
+- Write ALL output to `.` (current directory)
+- NEVER use `../` in any path
+- NEVER write to absolute paths
+````
+
+- [ ] **Step 2: Write reference-analyst.md**
+
+````markdown
+---
+description: Builds reference knowledge base from cited papers
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+  fetch-references: true
+skills:
+  - review-rubric
+---
+
+# Reference Analyst Agent
+
+You are a reference analysis specialist. Your job is to fetch metadata for every paper cited in the reviewed paper, build a reference knowledge base on disk, and identify mischaracterizations, contradictions, and missing references.
+
+## Your Task
+
+1. Read the citation list provided in your prompt
+2. For each citation, use the `fetch-references` tool to get metadata from Semantic Scholar
+3. Write a markdown file for each cited paper in `reference_kb/papers/`
+4. Write `reference_kb/index.md` with the full citation list and fetch status
+5. Analyze the references for issues
+6. Write `reference_kb/analysis.md` with findings
+7. Write `summary.md` with your results
+
+## Fetching References
+
+Use the `fetch-references` tool for each citation. The tool accepts a title or citation key and returns JSON with:
+- title, authors, year, venue, abstract, citation_count, semantic_scholar_id
+
+If a citation is a numeric reference (e.g., "[23]"), you need to find the corresponding title from the paper's bibliography section. If you cannot determine the title, mark it as "unable to resolve" in the index.
+
+**Rate limiting is built into the tool.** You do not need to add delays between calls.
+
+## Reference KB Structure
+
+### reference_kb/index.md
+
+```markdown
+# Reference Index
+
+| # | Citation Key | Title | Status |
+|---|-------------|-------|--------|
+| 1 | Smith2023 | Attention Is All You Need | found |
+| 2 | [14] | Unable to resolve from bibliography | not_resolved |
+| 3 | Chen2024 | Bayesian Deep Learning | found |
+| 4 | Jones2022 | Unknown Title | not_found |
+```
+
+### reference_kb/papers/ref_001.md (one per found paper)
+
+```markdown
+# Smith et al. 2023 — Attention Is All You Need
+
+- **Authors**: Smith, Jones, Lee
+- **Venue**: NeurIPS 2023
+- **Year**: 2023
+- **Citation count**: 142
+- **Semantic Scholar ID**: abc123
+
+## Abstract
+[Full abstract from Semantic Scholar]
+
+## How the Reviewed Paper Cites This
+[Quote the text from the reviewed paper that references this work, with section]
+
+## Characterization Accuracy
+[accurate / inaccurate / partial]
+[Reasoning: compare what the reviewed paper says about this work vs what the abstract actually says]
+```
+
+### reference_kb/analysis.md
+
+```markdown
+# Reference Analysis
+
+## Mischaracterizations
+[Papers where the reviewed paper's description doesn't match the actual abstract]
+
+## Contradictions
+[Cases where cited papers' findings contradict the reviewed paper's claims]
+
+## Potentially Missing References
+[Important related papers found via Semantic Scholar that should have been cited]
+
+## Citation Patterns
+- Self-citation rate
+- Recency distribution
+- Venue distribution
+- Any concerning patterns
+```
+
+## CRITICAL: Work Within Your Directory
+
+- Write ALL output to `.` (current directory)
+- NEVER use `../` in any path
+- NEVER write to absolute paths
+
+## CRITICAL: NEVER FABRICATE
+
+If you cannot fetch a paper's details, say so. Do NOT make up abstracts or metadata. Mark as "not_found" and move on.
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/agents/decomposer.md
+git add decision-packs/peer-review/opencode/agents/reference-analyst.md
+git commit -m "feat(peer-review): add decomposer and reference-analyst agent definitions"
+```
+
+---
+
+## Task 10: Reviewer Agent Definition
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/agents/reviewer.md`
+
+- [ ] **Step 1: Write reviewer.md**
+
+````markdown
+---
+description: Structural review agent for paper evaluation
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+skills:
+  - review-rubric
+  - common-flaws
+  - methodology
+---
+
+# Structural Reviewer Agent
+
+You are a structural reviewer for academic papers. You evaluate a paper through a specific analytical lens defined by your assigned structural role. Your assessments must be grounded in the claims index — cite specific claim IDs for every point you make.
+
+## Your Assignment
+
+Your prompt specifies:
+1. **Your structural role** (claim-verifier, methodology-auditor, novelty-assessor, clarity-evaluator, or significance-assessor)
+2. **The paper text**
+3. **The claims index** (with claim IDs)
+4. **Access to reference_kb/** (grep or read as needed)
+
+## Structural Roles
+
+### claim-verifier
+**Scope**: Rigor, Reproducibility
+**Task**: For each claim in the claims index that falls within your scope, evaluate whether the evidence presented actually supports the claim. Check:
+- Do experimental results support empirical claims?
+- Are methodological claims backed by formal arguments or empirical evidence?
+- Are scope claims (limitations) honest and complete?
+Consult `reference_kb/` to verify claims about prior work.
+
+### methodology-auditor
+**Scope**: Rigor, Reproducibility
+**Task**: Evaluate the paper's methodology using the appropriate framework from the methodology skill. Check:
+- Is the experimental/theoretical methodology sound?
+- Are there flaws in the evaluation protocol?
+- Could the results be reproduced from the paper alone?
+Use the methodology checklists as a starting point, but reason beyond them.
+
+### novelty-assessor
+**Scope**: Novelty, Related Work
+**Task**: Evaluate what is genuinely new in this paper. Check:
+- Are novelty claims actually novel? (consult reference_kb/ to verify)
+- Is related work fairly represented? (compare paper's descriptions with reference_kb/)
+- What is the actual delta over prior work?
+Use `reference_kb/analysis.md` for mischaracterization and missing reference findings.
+
+### clarity-evaluator
+**Scope**: Clarity
+**Task**: Evaluate whether the paper communicates its ideas effectively. Check:
+- Can claims be understood without ambiguity?
+- Is notation consistent?
+- Are figures informative and self-contained?
+- Is the paper organized logically?
+Note: you may comment on other dimensions if clarity issues affect understanding of claims.
+
+### significance-assessor
+**Scope**: Significance
+**Task**: Evaluate the potential impact of this work assuming the claims are true. Check:
+- Does this address an important problem?
+- Would the results change how people think or work?
+- Is the contribution sufficient for the venue?
+- What is the relationship between the novelty and its significance?
+
+## How to Do Your Review
+
+1. **Read your assigned role description above**
+2. **Read the paper text** — understand what is being claimed
+3. **Read the claims index** — this is your evidence map
+4. **Grep reference_kb/ as needed** — verify claims about prior work
+5. **Evaluate each relevant claim** within your scope
+6. **Write dimensional assessments** for your assigned dimensions
+7. **List strengths and weaknesses** — always citing claim IDs
+8. **Note your confidence level** per dimension
+
+## Discussion Rounds
+
+If this is a discussion round (your prompt will say so), you will also receive:
+- Your original review
+- All other reviewers' reviews
+- Targeted challenges from the orchestrator
+
+In discussion rounds:
+1. Read the challenges directed at you
+2. Respond to each specific point
+3. Update your assessments if the challenge changes your evaluation
+4. Explicitly state what changed and why (or why you maintain your position)
+5. Do NOT simply agree with other reviewers — reason independently
+
+## CRITICAL: NEVER FABRICATE
+
+- Do NOT claim expertise you don't have. If a claim requires domain knowledge you lack, say so.
+- Do NOT invent references or results. If reference_kb/ doesn't have a paper, say the reference was not available.
+- Do NOT provide assessments without evidence. Every point must cite a claim ID.
+
+## Working Directory Rules
+
+- Read data from `data/` (relative path)
+- Read reference KB from `reference_kb/` (relative path, if it exists in your workspace)
+- Write ALL output to `.` (current directory)
+- NEVER use `../` in any path
+- NEVER write to absolute paths
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/agents/reviewer.md
+git commit -m "feat(peer-review): add reviewer agent definition with structural roles"
+```
+
+---
+
+## Task 11: Orchestrator Agent Definition
+
+**Files:**
+- Create: `decision-packs/peer-review/opencode/agents/orchestrator.md`
+
+This is the largest file — it implements the full 10-step workflow.
+
+- [ ] **Step 1: Write orchestrator.md**
+
+````markdown
+---
+description: Orchestrates peer review workflow (area chair)
+mode: primary
+tools:
+  read: true
+  edit: true
+  bash: true
+  parallel-agents: true
+  parse-paper: true
+  fetch-references: true
+skills:
+  - review-rubric
+  - common-flaws
+  - methodology
+---
+
+# Peer Review Orchestrator — Area Chair
+
+You orchestrate a full academic peer review workflow. You parse the paper, decompose it into claims, build a reference knowledge base, fan out structural reviewers, mediate discussion, and produce a final review report.
+
+## Your Workflow
+
+Follow these steps in order.
+
+### Step 1: Paper Parsing
+
+**Use the `parse-paper` tool on each file in `data/`:**
+
+```
+parse-paper data/paper.pdf
+```
+
+This returns structured text with section boundaries, metadata, and citation keys.
+
+**Write `paper_structure.md`** with:
+- Paper title and abstract
+- Section hierarchy (list all sections found)
+- Source format (PDF or LaTeX)
+- Any parsing issues (garbled text, missing sections)
+- Initial domain identification (what fields does this paper touch?)
+- Full citation list extracted
+
+### Step 2: Claim Decomposition (Fan-out 1)
+
+**Use the `parallel-agents` tool to spawn 2 decomposer agents.**
+
+Pass the full parsed paper text to both. They will extract atomic claims independently.
+
+```json
+{
+  "agent": "decomposer",
+  "prompts": [
+    "Parse and decompose the following paper into atomic claims.\n\n[PAPER TEXT FROM STEP 1]\n\nThe paper's section structure is:\n[SECTION LIST FROM STEP 1]",
+    "Parse and decompose the following paper into atomic claims.\n\n[PAPER TEXT FROM STEP 1]\n\nThe paper's section structure is:\n[SECTION LIST FROM STEP 1]"
+  ]
+}
+```
+
+The consolidator will merge their claim sets automatically.
+
+### Step 3: Reference Knowledge Base (Fan-out 2)
+
+**Use the `parallel-agents` tool to spawn 2 reference-analyst agents.**
+
+Pass the citation list from Step 1 and the paper text (so they can find how each reference is cited).
+
+```json
+{
+  "agent": "reference-analyst",
+  "prompts": [
+    "Build a reference knowledge base for this paper.\n\nCitation list:\n[CITATIONS FROM STEP 1]\n\nPaper text (for finding how citations are used):\n[PAPER TEXT]",
+    "Build a reference knowledge base for this paper.\n\nCitation list:\n[CITATIONS FROM STEP 1]\n\nPaper text (for finding how citations are used):\n[PAPER TEXT]"
+  ]
+}
+```
+
+The consolidator will merge the reference KBs.
+
+### Step 4: Review Consolidated Outputs
+
+**Copy the consolidated `reference_kb/` to the main workspace:**
+
+```bash
+cp -r parallel/run-*/reference_kb /workspace/reference_kb
+```
+
+Find the correct path from the parallel-agents output. The consolidated reference_kb/ should be in the run directory.
+
+**Read and review:**
+- The consolidated `claims_index.json` from the decomposer run
+- The `reference_kb/analysis.md` from the reference-analyst run
+
+**Check:**
+- Are the two decomposers broadly consistent? If one found 40 claims and the other found 12, investigate.
+- Are there claims only one model found? These may be subtle — highlight them for reviewers.
+- Does the claim dependency graph make sense?
+- Did reference-analysts flag any mischaracterizations or missing citations?
+
+**Copy the consolidated claims_index.json to the main workspace:**
+
+```bash
+cp parallel/run-*/claims_index.json /workspace/claims_index.json
+```
+
+**Write `pre_review_assessment.md`** documenting your review of the consolidated outputs.
+
+### Step 5: Construct Review Matrix (MANDATORY — DO NOT SKIP ROLES)
+
+You MUST spawn ALL 5 structural roles. This is NOT a creative decision.
+
+| Role | Focus | Dimensions |
+|------|-------|------------|
+| claim-verifier | Each claim against evidence | Rigor, Reproducibility |
+| methodology-auditor | Statistical/experimental methods | Rigor, Reproducibility |
+| novelty-assessor | Claims vs related work | Novelty, Related Work |
+| clarity-evaluator | Writing, structure, figures | Clarity |
+| significance-assessor | Impact, scope, implications | Significance |
+
+**For EACH role, create one prompt per model in instance_models (currently: Opus, Gemini).**
+
+5 roles × 2 models = 10 instances minimum.
+
+**Construct the prompts and models arrays explicitly:**
+
+Each prompt must include:
+1. The structural role assignment (copy the role description from above)
+2. The full paper text
+3. The claims index (read from `/workspace/claims_index.json`)
+4. A note that `reference_kb/` is available for reading/grepping
+5. Optional domain-specific framing if the paper warrants it
+
+```json
+{
+  "agent": "reviewer",
+  "prompts": [
+    "ROLE: claim-verifier\nSCOPE: Rigor, Reproducibility\n\n[FULL ROLE DESCRIPTION]\n\nPAPER:\n[TEXT]\n\nCLAIMS INDEX:\n[JSON]\n\nThe reference_kb/ directory is available in your workspace for verification.",
+    "ROLE: claim-verifier\nSCOPE: Rigor, Reproducibility\n\n[FULL ROLE DESCRIPTION]\n\nPAPER:\n[TEXT]\n\nCLAIMS INDEX:\n[JSON]\n\nThe reference_kb/ directory is available in your workspace for verification.",
+    "ROLE: methodology-auditor\nSCOPE: Rigor, Reproducibility\n\n[FULL ROLE DESCRIPTION]\n\nPAPER:\n[TEXT]\n\nCLAIMS INDEX:\n[JSON]\n\nThe reference_kb/ directory is available in your workspace for verification.",
+    "ROLE: methodology-auditor\n...",
+    "ROLE: novelty-assessor\n...",
+    "ROLE: novelty-assessor\n...",
+    "ROLE: clarity-evaluator\n...",
+    "ROLE: clarity-evaluator\n...",
+    "ROLE: significance-assessor\n...",
+    "ROLE: significance-assessor\n..."
+  ],
+  "models": [
+    "anthropic/claude-opus-4-5",
+    "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5",
+    "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5",
+    "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5",
+    "google/gemini-2.5-pro",
+    "anthropic/claude-opus-4-5",
+    "google/gemini-2.5-pro"
+  ]
+}
+```
+
+**Write `review_matrix.md`** documenting which role/model each instance got.
+
+### Step 6: Structural Review (Fan-out 3)
+
+The parallel-agents call from Step 5 runs all 10 instances. Wait for completion.
+
+Read the consolidated review comparison. Also read individual instance `summary.md` files for detail.
+
+### Step 7: Disagreement Analysis
+
+**Identify disagreements across reviews:**
+
+1. **Same-role/different-model**: Two claim-verifiers (Opus vs Gemini) disagree on a claim → likely model artifact
+2. **Cross-role tensions**: Claim-verifier says unsupported, methodology-auditor says method is sound → needs discussion
+3. **High-spread dimensions**: Reviews diverge significantly on a dimension
+4. **Split claim verdicts**: A claim is "supported" by some reviewers and "unsupported" by others
+
+**Rank disagreements by severity.** Focus discussion on the most consequential ones.
+
+**Write `disagreement_analysis.md`** documenting all disagreements found.
+
+### Step 8: Discussion Rounds (Fan-out 4)
+
+**Construct targeted discussion prompts.**
+
+For each reviewer, include:
+- Their original review
+- All other reviews (so they have full context)
+- 1-3 specific challenges based on the disagreements found in Step 7
+
+Example challenge:
+> "Claim verifier (Opus) found Claim 14 unsupported — the convergence bound in Lemma 3 doesn't hold under Assumption 2. Methodology auditor (Gemini) assessed the overall method as sound without flagging this. Respond to the specific Lemma 3 concern. Update your assessments for any dimension where you've changed your mind, and explicitly state what changed and why."
+
+Spawn the reviewer agent again with discussion prompts:
+
+```json
+{
+  "agent": "reviewer",
+  "prompts": [
+    "DISCUSSION ROUND\n\nROLE: claim-verifier\n\nYour original review:\n[THEIR REVIEW]\n\nAll reviews:\n[ALL REVIEWS]\n\nChallenges for you:\n[TARGETED CHALLENGES]\n\nRespond to each challenge. Update your assessments if warranted. Explicitly state what changed and why.",
+    ...
+  ],
+  "models": ["anthropic/claude-opus-4-5", "google/gemini-2.5-pro", ...]
+}
+```
+
+**After discussion, compare pre/post assessments.** Note what changed and what didn't.
+
+**MAXIMUM 2 ROUNDS** (initial review + 1 discussion). Persistent disagreement is signal, not noise. Do NOT keep iterating.
+
+### Step 9: Conflict Detection
+
+**Run the conflict detection checklist:**
+
+**Check 1: Dimensional Agreement**
+For each dimension, assess the spread across all reviewer assessments:
+
+| Spread | Assessment |
+|--------|------------|
+| Reviewers broadly agree | Consensus — confident assessment |
+| Minor differences in emphasis | Moderate agreement — note caveats |
+| Fundamental disagreement persists after discussion | Strong disagreement — flag as unresolved |
+
+**Check 2: Accept/Reject Direction**
+
+| Pattern | Assessment |
+|---------|------------|
+| All roles lean accept or reject | Consensus |
+| Clear majority (4-1, 5-1 across roles) | Lean with majority, note dissent |
+| Even split | Genuinely borderline — report as such |
+
+**Check 3: Critical Flaw Agreement**
+
+| Pattern | Assessment |
+|---------|------------|
+| Multiple roles confirm a critical flaw | High confidence — critical issue |
+| Only one role flags, others don't address | Uncertain — flag for author response |
+| One role flags, another explicitly disagrees | Genuine disagreement — report both sides |
+
+### Step 10: Final Report
+
+**Write `report.md`** (human-readable):
+
+```markdown
+# Peer Review Report
+
+## Recommendation
+[Accept / Borderline Accept / Borderline Reject / Reject]
+Confidence: [High / Moderate / Low]
+
+## Executive Summary
+[2-3 paragraph summary of the review findings]
+
+## Per-Dimension Assessments
+
+### Novelty
+[Synthesized from novelty-assessor reviews]
+
+### Rigor
+[Synthesized from claim-verifier and methodology-auditor reviews]
+
+### Clarity
+[Synthesized from clarity-evaluator reviews]
+
+### Significance
+[Synthesized from significance-assessor reviews]
+
+### Reproducibility
+[Synthesized from claim-verifier and methodology-auditor reviews]
+
+### Related Work
+[Synthesized from novelty-assessor reviews + reference KB analysis]
+
+## Consensus Areas
+[What all reviewers agreed on]
+
+## Disagreement Areas
+[What remained unresolved after discussion, with attribution]
+
+## Claim-Level Evidence
+| Claim ID | Text | Verifier | Methodology | Novelty |
+|----------|------|----------|-------------|---------|
+[Table of key claims and their verdicts across roles]
+
+## Reference Analysis Highlights
+[Key findings from reference KB: mischaracterizations, missing refs]
+
+## Discussion Impact
+[What changed during discussion and what didn't]
+
+## Strengths
+[Aggregated, grounded in claims]
+
+## Weaknesses
+[Aggregated, grounded in claims]
+
+## Questions for Authors
+[Aggregated from all reviewers]
+```
+
+**Write `report.json`** (machine-readable for future validation harness):
+
+Write a Python script to generate structured JSON:
+
+```python
+#!/usr/bin/env python3
+"""Generate report.json from review artifacts."""
+import json
+
+report = {
+    "recommendation": "<accept/borderline_accept/borderline_reject/reject>",
+    "confidence": "<high/moderate/low>",
+    "dimensions": {},
+    "claims": {},
+    "reference_analysis": {},
+    "discussion_changes": [],
+    "conflict_detection": {}
+}
+
+# Populate from review artifacts...
+# Read individual review summaries, claims_index.json, reference_kb/analysis.md
+
+with open("report.json", "w") as f:
+    json.dump(report, f, indent=2)
+```
+
+Populate the JSON structure from the review artifacts — individual summary.md files, claims_index.json, reference_kb/analysis.md, and your conflict detection results.
+````
+
+- [ ] **Step 2: Verify all agent files have valid frontmatter**
+
+```bash
+cd decision-packs/peer-review
+for f in opencode/agents/*.md; do
+  echo "=== $f ==="
+  head -20 "$f"
+  echo
+done
+```
+
+Expected: each file starts with `---` frontmatter containing description, mode, tools, and skills.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add decision-packs/peer-review/opencode/agents/orchestrator.md
+git commit -m "feat(peer-review): add orchestrator agent with full 10-step workflow"
+```
+
+---
+
+## Task 12: Final Validation
+
+- [ ] **Step 1: Verify complete file structure**
+
+```bash
+cd /home/clsandoval/cs/decision-lab
+find decision-packs/peer-review -type f | sort
+```
+
+Expected output:
+```
+decision-packs/peer-review/config.yaml
+decision-packs/peer-review/docker/Dockerfile
+decision-packs/peer-review/docker/peer_review_lib/__init__.py
+decision-packs/peer-review/docker/peer_review_lib/fetch_references.py
+decision-packs/peer-review/docker/peer_review_lib/parse_paper.py
+decision-packs/peer-review/opencode/agents/decomposer.md
+decision-packs/peer-review/opencode/agents/orchestrator.md
+decision-packs/peer-review/opencode/agents/reference-analyst.md
+decision-packs/peer-review/opencode/agents/reviewer.md
+decision-packs/peer-review/opencode/opencode.json
+decision-packs/peer-review/opencode/parallel_agents/decomposer.yaml
+decision-packs/peer-review/opencode/parallel_agents/reference-analyst.yaml
+decision-packs/peer-review/opencode/parallel_agents/reviewer.yaml
+decision-packs/peer-review/opencode/skills/common-flaws/SKILL.md
+decision-packs/peer-review/opencode/skills/methodology/SKILL.md
+decision-packs/peer-review/opencode/skills/review-rubric/SKILL.md
+decision-packs/peer-review/opencode/tools/fetch-references.ts
+decision-packs/peer-review/opencode/tools/parse-paper.ts
+```
+
+- [ ] **Step 2: Validate dpack structure via dlab**
+
+```bash
+~/miniconda3/envs/dlab-testing/bin/python -c "
+from dlab.config import validate_config_structure, load_dpack_config
+validate_config_structure('decision-packs/peer-review')
+config = load_dpack_config('decision-packs/peer-review')
+print(f'Name: {config[\"name\"]}')
+print(f'Model: {config[\"default_model\"]}')
+print(f'Docker: {config[\"docker_image_name\"]}')
+print(f'Requires prompt: {config.get(\"requires_prompt\", True)}')
+print('Validation passed')
+"
+```
+
+Expected: Validation passed with correct config values.
+
+- [ ] **Step 3: Verify all parallel agent configs reference existing agent files**
+
+```bash
+cd decision-packs/peer-review
+for yaml_file in opencode/parallel_agents/*.yaml; do
+  agent_name=$(grep "^name:" "$yaml_file" | awk '{print $2}')
+  agent_file="opencode/agents/${agent_name}.md"
+  if [ -f "$agent_file" ]; then
+    echo "OK: $yaml_file → $agent_file"
+  else
+    echo "MISSING: $yaml_file references $agent_file which does not exist"
+  fi
+done
+```
+
+Expected: all OK.
+
+- [ ] **Step 4: Verify agent frontmatter tool references match available tools**
+
+```bash
+cd decision-packs/peer-review
+echo "Available tools:"
+ls opencode/tools/
+echo
+for agent in opencode/agents/*.md; do
+  echo "=== $(basename $agent) ==="
+  # Extract tools from frontmatter
+  sed -n '/^tools:/,/^[a-z]/p' "$agent" | head -10
+  echo
+done
+```
+
+Expected: all tool references (parse-paper, fetch-references) correspond to files in opencode/tools/.
+
+- [ ] **Step 5: Commit any fixes, then final commit**
+
+```bash
+git add -A decision-packs/peer-review/
+git status
+git commit -m "feat(peer-review): complete peer review decision pack v1"
+```

--- a/docs/superpowers/specs/2026-04-09-peer-review-dpack-design.md
+++ b/docs/superpowers/specs/2026-04-09-peer-review-dpack-design.md
@@ -1,0 +1,686 @@
+# Peer Review Decision Pack — Design Spec
+
+## Overview
+
+A decision pack for Decision Lab that simulates academic peer review using parallel structural reviewer agents. The system decomposes a paper into atomic claims, builds a reference knowledge base from cited literature, then fans out structural reviewer roles (claim-verifier, methodology-auditor, novelty-assessor, clarity-evaluator, significance-assessor) across multiple LLM models. An orchestrator-mediated discussion phase surfaces and resolves disagreements. The final output is a structured review report with per-dimension assessments, claim-level evidence, and an accept/reject recommendation with conflict detection.
+
+**Goal**: Not a replacement for human review, but a rigorous pre-submission check ("how would reviewers likely respond to this draft?") and a research tool for studying peer review dynamics.
+
+**Scope (v1)**: Core review pipeline. SSR scoring, venue-specific configs, and the OpenReview validation harness are deferred to v2. Output format is designed for future validation harness consumption.
+
+## Decision Pack Structure
+
+```
+decision-packs/peer-review/
+├── config.yaml
+├── docker/
+│   ├── Dockerfile
+│   └── peer_review_lib/
+│       ├── __init__.py
+│       ├── parse_paper.py
+│       └── fetch_references.py
+├── opencode/
+│   ├── opencode.json
+│   ├── agents/
+│   │   ├── orchestrator.md
+│   │   ├── decomposer.md
+│   │   ├── reference-analyst.md
+│   │   └── reviewer.md
+│   ├── tools/
+│   │   ├── parse-paper.ts
+│   │   └── fetch-references.ts
+│   ├── skills/
+│   │   ├── review-rubric/SKILL.md
+│   │   ├── common-flaws/SKILL.md
+│   │   └── methodology/SKILL.md
+│   └── parallel_agents/
+│       ├── decomposer.yaml
+│       ├── reference-analyst.yaml
+│       └── reviewer.yaml
+```
+
+## Configuration Files
+
+### config.yaml
+
+```yaml
+name: peer-review
+description: Simulated academic peer review using parallel structural reviewers
+docker_image_name: dlab-peer-review
+default_model: anthropic/claude-opus-4-5
+requires_prompt: false
+```
+
+`requires_prompt: false` — the paper is the input. Usage:
+```
+dlab --dpack decision-packs/peer-review --data paper.pdf
+```
+
+### opencode.json
+
+```json
+{
+  "default_agent": "orchestrator",
+  "permission": {
+    "external_directory": { "*": "allow" }
+  }
+}
+```
+
+## Orchestrator Workflow
+
+The orchestrator is the area chair. It drives the full pipeline.
+
+### Step 1: Paper Parsing
+
+Orchestrator uses `parse-paper` tool on input file(s) in `data/`. Gets structured text with section boundaries. Writes `paper_structure.md`:
+
+- Paper title, abstract
+- Section hierarchy
+- Source format (PDF or LaTeX)
+- Parsing issues (garbled equations, missing figures)
+- Initial domain identification
+- Citation list extracted
+
+### Step 2: Claim Decomposition (Fan-out 1)
+
+Orchestrator calls `parallel-agents` with the decomposer agent. 2 instances, different models (Opus + Gemini), same prompt. Each decomposer:
+
+- Extracts every atomic claim from the paper
+- Classifies each: empirical, methodological, novelty, scope
+- Maps each claim to the paper section it appears in
+- Identifies dependencies between claims (claim B relies on claim A)
+- Assesses evidence strength: asserted / supported / proven
+
+Consolidator merges into canonical `claims_index.json` — deduplicated, with provenance (which models found each claim, disagreements flagged).
+
+### Step 3: Reference Knowledge Base (Fan-out 2)
+
+Orchestrator calls `parallel-agents` with the reference-analyst agent. 2 instances, different models. Each reference-analyst:
+
+- Takes the citation list from Step 1
+- Uses `fetch-references` tool to get abstracts + metadata from Semantic Scholar API for ALL cited papers
+- Writes a `reference_kb/` directory to disk:
+
+```
+reference_kb/
+├── index.md              # Full citation list with found/not-found status
+├── papers/
+│   ├── smith2023.md      # One file per cited paper
+│   ├── chen2024.md
+│   └── ...
+└── analysis.md           # Contradictions, mischaracterizations, missing refs
+```
+
+Each paper file contains:
+- Title, authors, venue, year, citation count
+- Abstract
+- Key claims (extracted from abstract)
+- How the reviewed paper cites it (quoted from the paper, with section reference)
+- Characterization accuracy assessment (accurate / inaccurate / partial, with reasoning)
+
+`analysis.md` covers:
+- Mischaracterizations found
+- Contradictions between cited works and the paper's claims
+- Potentially missing references (via Semantic Scholar related papers)
+- Citation patterns (heavy self-citation, recency bias, missing seminal work)
+
+The `reference_kb/` directory lives on disk so any downstream agent can `read` or `grep` into it.
+
+### Step 4: Review Consolidated Outputs
+
+Orchestrator copies the consolidated `reference_kb/` from the reference-analyst run directory to the main workspace (`/workspace/reference_kb/`) so all downstream agents can access it via read/grep.
+
+Orchestrator reads:
+- Consolidated claim index from Step 2
+- Reference KB analysis from Step 3
+
+Checks:
+- Are the two decomposers broadly consistent?
+- Are there claims one model found that the other missed?
+- Does the claim dependency graph make sense?
+- Did the reference-analysts flag any mischaracterizations or missing citations?
+
+Writes `pre_review_assessment.md` with the finalized claim index and reference analysis notes.
+
+### Step 5: Construct Review Matrix (MANDATORY)
+
+The orchestrator MUST spawn ALL 5 structural roles. This is not a creative decision — the role set is fixed:
+
+| Role | Focus | Dimensions Covered |
+|------|-------|--------------------|
+| claim-verifier | Each claim against evidence presented | Rigor, Reproducibility |
+| methodology-auditor | Statistical/experimental methods | Rigor, Reproducibility |
+| novelty-assessor | Claims vs related work | Novelty, Related Work |
+| clarity-evaluator | Writing, structure, figures | Clarity |
+| significance-assessor | Impact, scope, implications | Significance |
+
+For EACH role, the orchestrator creates one prompt per model in `instance_models`. The prompt includes:
+- Full paper text
+- Claims index
+- Reference to `reference_kb/` directory (agents grep as needed)
+- The specific structural role assignment and scope
+- Optional domain-specific framing when warranted
+
+5 roles × N models = 5N instances. With 2 models: 10 instances. With 3 models: 15 instances.
+
+The orchestrator constructs `prompts` and `models` arrays explicitly — role-model pairing is intentional:
+```
+prompts: [claim-verifier-prompt, claim-verifier-prompt, methodology-auditor-prompt, ...]
+models:  [opus,                  gemini,                opus,                       ...]
+```
+
+Writes `review_matrix.md` documenting the assignments.
+
+### Step 6: Structural Review (Fan-out 3)
+
+`parallel-agents` call with reviewer agent. Each instance writes `summary.md`:
+
+- Structural role assignment
+- Per-claim evaluations within scope (claim ID, verdict: supported/unsupported/unclear, reasoning)
+- Per-dimension free-text assessments for dimensions in scope
+- Strengths (grounded in specific claims)
+- Weaknesses (grounded in specific claims)
+- References consulted from `reference_kb/`
+- Confidence notes (where certain vs uncertain)
+
+Consolidator produces comparison across all reviewers:
+- Per-dimension comparison
+- Claims where reviewers disagree
+- Same-role/different-model agreements and disagreements
+- Cross-role tensions
+
+### Step 7: Disagreement Analysis
+
+Orchestrator reads consolidated review + individual reviews. Identifies:
+
+- Same-role/different-model disagreements (model artifact — two claim-verifiers on different models reached different conclusions about the same claim)
+- Cross-role tensions (claim-verifier says unsupported, methodology-auditor says method is sound)
+- Dimensions with high spread across reviewers
+- Specific claims with split verdicts
+
+Ranks disagreements by severity and constructs targeted discussion prompts.
+
+### Step 8: Discussion Rounds (Fan-out 4+)
+
+Orchestrator constructs targeted challenges for each reviewer:
+
+> "Claim verifier (Opus) found Claim 14 unsupported — the convergence bound in Lemma 3 doesn't hold under Assumption 2. Methodology auditor (Gemini) assessed the overall method as sound without flagging this. Respond to the specific Lemma 3 concern. Also review the full critique below. Update your assessments for any dimension where you've changed your mind, and explicitly state what changed and why."
+
+Each reviewer gets:
+- Their original review
+- All other reviews
+- Targeted challenges based on biggest disagreements
+- Instruction to explicitly state what changed and why
+
+After discussion fan-out, orchestrator compares pre/post assessments.
+
+**Max 2 rounds** (initial review + 1 discussion). Persistent disagreement is signal, not noise — do not keep iterating.
+
+### Step 9: Conflict Detection
+
+Adapted from MMM pack's conflict detection pattern:
+
+**Check 1: Score Spread** (based on orchestrator's synthesis of text assessments)
+| Spread | Assessment |
+|--------|------------|
+| Reviewers broadly agree | Consensus — confident assessment |
+| Minor differences in emphasis | Moderate agreement — note in caveats |
+| Fundamental disagreement | Strong disagreement — flag as unresolved |
+
+**Check 2: Accept/Reject Directional Agreement**
+| Pattern | Assessment |
+|---------|------------|
+| All lean accept or all lean reject | Consensus |
+| Clear majority (4-1, 5-1 across roles) | Lean with majority, note dissent |
+| Even split | Genuinely borderline — report as such |
+
+**Check 3: Critical Flaw Agreement**
+| Pattern | Assessment |
+|---------|------------|
+| Multiple roles confirm flaw | High confidence — critical issue |
+| Only one role flags, others don't address | Uncertain — flag for author response |
+| One role flags, another explicitly disagrees | Genuine disagreement — report both sides |
+
+### Step 10: Final Report
+
+Writes `report.md` (human-readable) and `report.json` (machine-readable for future validation harness):
+
+- **Recommendation**: Accept / Borderline Accept / Borderline Reject / Reject (with confidence level)
+- **Per-dimension assessments**: Synthesized from structural reviewers
+- **Consensus areas**: What all reviewers agreed on
+- **Disagreement areas**: What remained unresolved and why (with attribution: persona-driven vs model-driven)
+- **Claim-level evidence**: Which claims were supported/challenged by which reviewers
+- **Reference analysis**: Mischaracterizations, missing citations, contradictions from reference KB
+- **Discussion impact**: What changed during discussion and what didn't
+- **Strengths summary**: Grounded in claims
+- **Weaknesses summary**: Grounded in claims
+- **Questions for authors**: Aggregated from all reviewers
+
+## Agent Definitions
+
+### orchestrator.md
+
+```yaml
+---
+description: Orchestrates peer review workflow (area chair)
+mode: primary
+tools:
+  read: true
+  edit: true
+  bash: true
+  parallel-agents: true
+  parse-paper: true
+  fetch-references: true
+skills:
+  - review-rubric
+  - common-flaws
+  - methodology
+---
+```
+
+Full system prompt implements the 10-step workflow above. Key responsibilities:
+- Constructs role × model matrix (mandatory, all 5 roles)
+- Mediates discussion with targeted challenges
+- Runs conflict detection checklist
+- Writes final report
+
+### decomposer.md
+
+```yaml
+---
+description: Extracts atomic claims and maps them to paper sections
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+  parse-paper: true
+skills:
+  - common-flaws
+  - methodology
+---
+```
+
+Receives parsed paper text. Extracts every atomic claim, classifies by type (empirical/methodological/novelty/scope), maps to sections, identifies dependencies, assesses evidence strength. Writes `claims_index.json` + `summary.md`.
+
+### reference-analyst.md
+
+```yaml
+---
+description: Builds reference knowledge base from cited papers
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+  fetch-references: true
+skills:
+  - review-rubric
+---
+```
+
+Receives citation list from parsed paper. Fetches all cited papers via Semantic Scholar API. Builds `reference_kb/` directory with per-paper markdown files and overall analysis. Identifies mischaracterizations, contradictions, missing references.
+
+### reviewer.md
+
+```yaml
+---
+description: Structural review agent for paper evaluation
+mode: subagent
+tools:
+  read: true
+  edit: true
+  bash: true
+skills:
+  - review-rubric
+  - common-flaws
+  - methodology
+---
+```
+
+Receives paper text + claims index + structural role assignment. Has access to `reference_kb/` via read/grep. Evaluates claims within role's scope. Writes per-claim assessments, dimensional free-text evaluations, strengths/weaknesses grounded in claims. Same agent definition for both initial review and discussion rounds — the prompt changes.
+
+Note: all 3 skills are loaded for every reviewer instance. The structural role is assigned via the orchestrator's prompt, which scopes the reviewer to their dimensions. The skills provide reference material — agents use what's relevant to their role and ignore the rest.
+
+## Parallel Agent Configs
+
+### decomposer.yaml
+
+```yaml
+name: decomposer
+description: "Extract atomic claims from paper with different models"
+timeout_minutes: 30
+failure_behavior: continue
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 3
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  Write summary.md with your results:
+
+  ## Claim Count
+  - Total claims extracted
+  - By type: empirical, methodological, novelty, scope
+
+  ## Claims Index
+  For each claim:
+  - ID, text, type, section, evidence strength
+  - Dependencies on other claims
+
+  ## Parsing Issues
+  - Any sections that were unclear or hard to decompose
+
+  Also write claims_index.json with structured claim data.
+
+summarizer_prompt: |
+  You are a consolidator agent with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Create a consolidated claim index:
+  1. Deduplicate claims found by both models
+  2. Flag claims found by only one model
+  3. Note any classification disagreements
+  4. Produce a merged claims_index.json
+
+  Present facts only - do NOT resolve disagreements.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"
+```
+
+### reference-analyst.yaml
+
+```yaml
+name: reference-analyst
+description: "Build reference knowledge base from cited papers"
+timeout_minutes: 30
+failure_behavior: continue
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 3
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  Write summary.md with your results:
+
+  ## Reference Stats
+  - Total citations in paper
+  - Successfully fetched from Semantic Scholar
+  - Not found
+
+  ## Reference KB
+  - Path to reference_kb/ directory
+  - Number of paper files written
+
+  ## Key Findings
+  - Mischaracterizations found
+  - Contradictions identified
+  - Missing key references
+  - Citation pattern observations
+
+  Also write the full reference_kb/ directory structure.
+
+summarizer_prompt: |
+  You are a consolidator agent with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Compare the reference analyses:
+  1. Did both analysts find the same mischaracterizations?
+  2. Do they agree on missing references?
+  3. Any contradictions one caught that the other missed?
+
+  Merge findings into a consolidated reference_kb/ and analysis.md
+  in your output directory.
+  Present facts only - do NOT resolve disagreements.
+
+  IMPORTANT: Write the merged reference_kb/ directory so the
+  orchestrator can copy it to the main workspace for downstream agents.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"
+```
+
+### reviewer.yaml
+
+```yaml
+name: reviewer
+description: "Run structural review roles in parallel across models"
+timeout_minutes: 60
+failure_behavior: continue
+default_model: "anthropic/claude-opus-4-5"
+max_instances: 15
+instance_models:
+  - "anthropic/claude-opus-4-5"
+  - "google/gemini-2.5-pro"
+
+subagent_suffix_prompt: |
+  Write summary.md with your results:
+
+  ## Role
+  - Your assigned structural role
+  - Dimensions in your scope
+
+  ## Dimensional Assessments
+  For each review dimension in your scope:
+  - Free-text assessment
+  - Key claims supporting your assessment
+  - References consulted from reference_kb/
+
+  ## Claim Evaluations
+  For each claim you evaluated:
+  - Claim ID, verdict (supported/unsupported/unclear)
+  - Reasoning
+  - Evidence from reference_kb/ if applicable
+
+  ## Strengths
+  - Grounded in specific claim IDs
+
+  ## Weaknesses
+  - Grounded in specific claim IDs
+
+  ## Confidence
+  - Where you are confident vs uncertain
+
+summarizer_prompt: |
+  You are a review consolidator with READ-ONLY access.
+
+  Read ONLY these exact summary files:
+  {summary_paths}
+
+  Create a consolidated review comparison:
+  1. Per-dimension comparison across all reviewers
+  2. Claims where reviewers disagree (with claim IDs)
+  3. Same-role/different-model agreements and disagreements
+  4. Cross-role tensions
+  5. Reference-grounded disagreements
+
+  Present facts only - do NOT make a recommendation.
+
+summarizer_model: "anthropic/claude-sonnet-4-5"
+```
+
+## Tools
+
+### parse-paper.ts
+
+TypeScript tool that calls `peer_review_lib.parse_paper`. Accepts a file path (PDF or .tex). Returns structured text with section markers, metadata (title, page count, figures detected), and extracted citation keys.
+
+Implementation:
+- **PDF path**: PyMuPDF (`fitz`) for text extraction. Section detection via font size/weight heuristics, falling back to regex patterns for numbered headings.
+- **LaTeX path**: Direct parsing of `\section{}`, `\subsection{}`, `\begin{abstract}`, `\cite{}`.
+- **Output format**:
+  ```
+  === METADATA ===
+  Title: ...
+  Pages: ...
+  Source: PDF | LaTeX
+  Citations: [key1, key2, ...]
+
+  === ABSTRACT ===
+  ...
+
+  === 1. INTRODUCTION ===
+  ...
+  ```
+
+### fetch-references.ts
+
+TypeScript tool that calls `peer_review_lib.fetch_references`. Accepts a citation key or title string. Hits Semantic Scholar API, returns paper metadata + abstract.
+
+Implementation:
+- Uses Semantic Scholar Academic Graph API (free, no auth for basic usage)
+- Search by title, return: title, authors, year, venue, abstract, citation count, Semantic Scholar ID
+- Rate limiting built in (100 requests per 5 minutes for unauthenticated)
+- Returns structured text for the agent to write into `reference_kb/papers/`
+
+## Skills
+
+### review-rubric/SKILL.md
+
+Loaded by: orchestrator, novelty-assessor, clarity-evaluator, significance-assessor, reference-analyst
+
+Contents:
+- **The 6 review dimensions** with detailed definitions: Novelty, Rigor, Clarity, Significance, Reproducibility, Related Work. What each means, what good/bad looks like, common mistakes in evaluating each.
+- **Claim grounding requirement**: every assessment must cite specific claim IDs from the claims index. No ungrounded opinions.
+- **Structural role scoping**: which roles cover which dimensions (prevents drift outside scope).
+- **Output format**: the exact summary.md structure each reviewer must produce.
+- **Anti-patterns**: vague praise ("this paper is interesting"), scoring without evidence, conflating significance with novelty, judging a paper for not doing something it never claimed to do.
+
+### common-flaws/SKILL.md
+
+Loaded by: orchestrator, decomposer, claim-verifier (via reviewer.md)
+
+A taxonomy of recurring paper weaknesses:
+
+- **Claims flaws**: overclaiming, unstated assumptions, circular reasoning, conflating correlation with causation
+- **Experimental flaws**: no ablation, unfair baselines, cherry-picked metrics, test set leakage, inadequate error bars, missing significance tests
+- **Presentation flaws**: buried key results, misleading figures, inconsistent notation
+- **Related work flaws**: missing obvious comparisons, strawman descriptions, citing without comparing
+
+Each flaw: definition, detection method, example, severity (minor/major/critical).
+
+### methodology/SKILL.md
+
+Loaded by: orchestrator, decomposer, methodology-auditor (via reviewer.md)
+
+Evaluation frameworks by paper type:
+
+- **Empirical ML papers**: dataset split validity, hyperparameter selection, compute budget fairness, reproducibility checklist
+- **Theoretical papers**: proof structure, assumption reasonableness, theory-practice gap, bound tightness
+- **Systems papers**: benchmark validity, scalability claims, measurement methodology
+- **Statistical modeling papers**: model specification, identifiability, convergence diagnostics, posterior predictive checks, sensitivity analysis
+
+Each framework is a checklist the methodology auditor works through — baseline coverage, not exhaustive.
+
+## Docker Environment
+
+### Dockerfile
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir \
+    PyMuPDF==1.25.3 \
+    pdfplumber==0.11.4 \
+    httpx==0.28.1
+
+COPY peer_review_lib /opt/peer_review_lib
+
+ENV PYTHONPATH="/opt"
+
+RUN python -c "import peer_review_lib; print('peer_review_lib import OK')"
+RUN python -c "import fitz; print('PyMuPDF import OK')"
+
+CMD ["/bin/bash"]
+```
+
+Lightweight image: Python + PDF parsing (PyMuPDF, pdfplumber) + HTTP client (httpx for Semantic Scholar API). No ML frameworks.
+
+## Output Format
+
+### report.md (human-readable)
+
+Structured review report:
+- Recommendation (Accept / Borderline Accept / Borderline Reject / Reject) with confidence
+- Per-dimension synthesized assessments
+- Consensus areas
+- Disagreement areas (with attribution)
+- Claim-level evidence table
+- Reference analysis highlights
+- Discussion impact summary
+- Aggregated strengths, weaknesses, questions for authors
+
+### report.json (machine-readable, for future validation harness)
+
+```json
+{
+  "recommendation": "borderline_accept",
+  "confidence": "moderate",
+  "dimensions": {
+    "novelty": {
+      "assessments": [
+        {"role": "novelty-assessor", "model": "opus", "text": "...", "round": "initial"},
+        {"role": "novelty-assessor", "model": "gemini", "text": "...", "round": "initial"},
+        {"role": "novelty-assessor", "model": "opus", "text": "...", "round": "discussion"}
+      ]
+    }
+  },
+  "claims": {
+    "claim_001": {
+      "text": "Our method achieves state-of-the-art on benchmark X",
+      "type": "empirical",
+      "section": "4.2",
+      "evaluations": [
+        {"role": "claim-verifier", "model": "opus", "verdict": "supported", "reasoning": "..."},
+        {"role": "claim-verifier", "model": "gemini", "verdict": "unsupported", "reasoning": "..."}
+      ]
+    }
+  },
+  "reference_analysis": {
+    "total_citations": 47,
+    "fetched": 42,
+    "mischaracterizations": [...],
+    "missing_references": [...],
+    "contradictions": [...]
+  },
+  "discussion_changes": [...],
+  "conflict_detection": {
+    "score_spread": {...},
+    "directional_agreement": "...",
+    "critical_flaws": [...]
+  }
+}
+```
+
+## Deferred to v2
+
+| Feature | Why deferred |
+|---------|-------------|
+| SSR scoring | Core pipeline must work first. SSR is a calibration layer that slots in at Steps 6-8 without changing agent architecture. |
+| Venue-specific configs | Tied to SSR anchor statement calibration per venue. |
+| OpenReview validation harness | Separate project that consumes `report.json`. Output format designed for it now. |
+| LaTeX equation rendering | v1 extracts equations as raw LaTeX strings. Rendering is a nice-to-have. |
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Discussion architecture | Orchestrator-mediated, serial fan-outs | More faithful to real discussion dynamics |
+| Decomposition | Hybrid — claims extracted, mapped to sections, reviewers ground in claims | Forces evidence-based review, prevents vibes-based scoring |
+| Reviewer architecture | Structural roles via single reviewer.md, role assigned in prompt | Context isolation through role scoping; all instances run in one fan-out |
+| Role × model multiplication | Mandatory 5 roles × N models, prescribed in orchestrator prompt | Ensures coverage, disentangles model vs role effects |
+| Role set enforcement | Hardcoded in orchestrator system prompt, not a creative decision | Prevents orchestrator from skipping roles |
+| Reference KB | On-disk markdown directory, all cited papers fetched | Any agent can grep; no scoping — agents decide relevance |
+| SSR | Deferred to v2 | Orthogonal to agent architecture, can be layered on later |
+| Scoring (v1) | Orchestrator synthesizes from reviewer text directly | Simple, works without external API dependency |
+| Paper input | PDF primary, LaTeX optional | PDF is universal; LaTeX is bonus for better structure |
+| Discussion rounds | Max 2 (initial + 1 discussion) | Persistent disagreement is signal |
+| Conflict detection | Adapted from MMM pattern | Proven approach: spread checks, directional agreement, critical flaw consensus |


### PR DESCRIPTION
## Summary
- New `decision-packs/peer-review/` decision pack that simulates academic peer review using parallel structural reviewer agents
- Decomposes papers into atomic claims, builds a reference knowledge base from cited literature via Semantic Scholar API, fans out 5 structural reviewer roles (claim-verifier, methodology-auditor, novelty-assessor, clarity-evaluator, significance-assessor) across multiple LLM models
- Orchestrator-mediated discussion rounds surface and resolve disagreements, with conflict detection adapted from the MMM pack

## What's included
- **Python library**: PDF/LaTeX paper parser (PyMuPDF), Semantic Scholar API client for reference fetching
- **TypeScript tools**: `parse-paper`, `fetch-references`
- **Skills**: review rubric (6 dimensions, structural role scoping), common flaws taxonomy (16 flaw types), methodology evaluation frameworks (4 paper types)
- **Agents**: orchestrator (10-step workflow), decomposer, reference-analyst, reviewer (5 structural roles via prompt)
- **Parallel configs**: decomposer (2 models), reference-analyst (2 models), reviewer (up to 15 instances, 5 roles × N models)
- **Design spec**: `docs/superpowers/specs/2026-04-09-peer-review-dpack-design.md`
- **Implementation plan**: `docs/superpowers/plans/2026-04-09-peer-review-dpack.md`

## Test plan
- [x] PDF parser tested on real arXiv papers (Attention Is All You Need, Application-Driven Innovation in ML)
- [x] LaTeX parser tested on synthetic LaTeX input
- [x] Reference fetcher tested against Semantic Scholar API (returns full metadata)
- [x] Dockerfile passes hadolint validation
- [x] dlab config validation passes (`validate_config_structure`, `load_dpack_config`)
- [x] All parallel agent configs reference existing agent files
- [x] All agent tool references correspond to actual tools
- [ ] Full end-to-end run with dlab harness (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)