### PR TITLE
TUI renders faster and breaks less frequently

### DIFF
--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -370,14 +370,25 @@ class ConnectApp(App):
         main_display_name = self._get_display_name("main")
 
         # Check if main agent is complete — if so, all sub-agents are done
-        # (sub-agents may lack a clean stop event if the container was killed)
+        # (sub-agents may lack a clean stop event if the container was killed).
+        # Cache the result on AgentState so we never re-parse a completed file.
         main_log = self._get_log_path("main")
-        main_complete = main_log.exists() and is_log_complete(main_log)
+        main_agent_state = self._state.agents.get(main_display_name)
+        if main_agent_state and main_agent_state.is_complete:
+            main_complete = True
+        else:
+            main_complete = main_log.exists() and is_log_complete(main_log)
+            if main_complete and main_agent_state:
+                main_agent_state.is_complete = True
 
         if not main_complete:
             for name in self._state.agents.keys():
-                log_path = self._get_log_path(name)
-                if log_path.exists() and not is_log_complete(log_path):
+                agent_state = self._state.agents[name]
+                if not agent_state.is_complete:
+                    log_path = self._get_log_path(name)
+                    if log_path.exists() and is_log_complete(log_path):
+                        agent_state.is_complete = True
+                if not agent_state.is_complete:
                     running.add(name)
 
         agent_selector.update_agents(agents, running)

--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -252,9 +252,6 @@ class ConnectApp(App):
         self._watcher = LogWatcher(self._logs_dir)
         self._watcher.start()
 
-        # Poll for initial events (populates queue before processing)
-        self._watcher.poll()
-
         # Process initial events
         self._process_pending_events()
 

--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -207,7 +207,7 @@ class ConnectApp(App):
         self._default_agent = load_default_agent(work_dir)
         self._search_matches: list[int] = []
         self._current_match_index: int = 0
-        self._logger = self._make_logger(work_dir)
+        self._file_logger = self._make_logger(work_dir)
 
     @staticmethod
     def _make_logger(work_dir: Path) -> logging.Logger:
@@ -269,38 +269,38 @@ class ConnectApp(App):
 
     async def _mount_impl(self) -> None:
         """Core mount logic — called by on_mount inside a try/except."""
-        self._logger.info("mount start | logs_dir=%s", self._logs_dir)
+        self._file_logger.info("mount start | logs_dir=%s", self._logs_dir)
         self.title = f"dlab connect - {self._work_dir.name}"
 
         # Check if job is running
         main_log = self._logs_dir / "main.log"
-        self._logger.info("main.log exists=%s", main_log.exists())
+        self._file_logger.info("main.log exists=%s", main_log.exists())
         try:
             self._state.is_job_running = main_log.exists() and not is_log_complete(
                 main_log
             )
-            self._logger.info("is_job_running=%s", self._state.is_job_running)
+            self._file_logger.info("is_job_running=%s", self._state.is_job_running)
         except Exception:
-            self._logger.exception("is_log_complete(main_log) failed")
+            self._file_logger.exception("is_log_complete(main_log) failed")
             self._state.is_job_running = True  # assume still running if we can't tell
 
         # Get global start timestamp from main.log FIRST
         # This is the authoritative reference for all relative timestamps
         self._state.global_start_ts = get_global_start_ts(self._logs_dir)
-        self._logger.info("global_start_ts=%s", self._state.global_start_ts)
+        self._file_logger.info("global_start_ts=%s", self._state.global_start_ts)
 
         # Start log watcher
         self._watcher = LogWatcher(self._logs_dir)
         self._watcher.start()
         initial_events = self._watcher.get_events()
-        self._logger.info("watcher.start() produced %d events", len(initial_events))
+        self._file_logger.info("watcher.start() produced %d events", len(initial_events))
         # Re-queue the events we just drained for inspection
         for item in initial_events:
             self._watcher._event_queue.put(item)
 
         # Process initial events
         self._process_pending_events()
-        self._logger.info(
+        self._file_logger.info(
             "after process_pending: %d agents, total_cost=%.4f",
             len(self._state.agents),
             self._state.total_cost,
@@ -318,7 +318,7 @@ class ConnectApp(App):
 
         # Start periodic update timer
         self._update_timer = self.set_interval(0.5, self._on_update_tick)
-        self._logger.info("mount complete — timer started")
+        self._file_logger.info("mount complete — timer started")
 
     async def on_unmount(self) -> None:
         """Cleanup on app unmount."""
@@ -375,7 +375,7 @@ class ConnectApp(App):
             try:
                 self._update_agent_list()
             except Exception:
-                self._logger.exception(
+                self._file_logger.exception(
                     "_update_agent_list failed (agents=%d)", len(self._state.agents)
                 )
             self._update_status_bar()
@@ -482,19 +482,19 @@ class ConnectApp(App):
                 self._watcher.poll()
             self._process_pending_events()
         except Exception:
-            self._logger.exception("_on_update_tick: poll/process failed")
+            self._file_logger.exception("_on_update_tick: poll/process failed")
 
         # Always refresh status bar so the UI doesn't freeze if process_pending throws.
         try:
             self._update_status_bar()
         except Exception:
-            self._logger.exception("_on_update_tick: _update_status_bar failed")
+            self._file_logger.exception("_on_update_tick: _update_status_bar failed")
 
         try:
             artifact_list = self.query_one("#artifact-list", ArtifactList)
             artifact_list.refresh_if_changed()
         except Exception:
-            self._logger.exception("_on_update_tick: artifact refresh failed")
+            self._file_logger.exception("_on_update_tick: artifact refresh failed")
 
     def on_agent_selector_agent_selected(
         self, event: AgentSelector.AgentSelected

--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -292,13 +292,9 @@ class ConnectApp(App):
         # Start log watcher
         self._watcher = LogWatcher(self._logs_dir)
         self._watcher.start()
-        initial_events = self._watcher.get_events()
-        self._file_logger.info("watcher.start() produced %d events", len(initial_events))
-        # Re-queue the events we just drained for inspection
-        for item in initial_events:
-            self._watcher._event_queue.put(item)
 
-        # Process initial events
+        # Process the initial events produced by start(). _process_pending_events
+        # drains the watcher queue itself, so we must not drain it first here.
         self._process_pending_events()
         self._file_logger.info(
             "after process_pending: %d agents, total_cost=%.4f",
@@ -408,14 +404,21 @@ class ConnectApp(App):
         return log_path
 
     def _is_agent_complete_in_memory(self, agent_state: AgentState) -> bool:
-        """Check completion from already-loaded events — no disk I/O."""
+        """Check completion from already-loaded events — no disk I/O.
+
+        Mirrors ``is_log_complete``: any ``error`` event means complete, and
+        that takes priority over the final ``step_finish`` reason. We therefore
+        scan the whole list for an error rather than returning on the first
+        terminal event, while still using the last ``step_finish`` (first one
+        seen when iterating in reverse) for the reason check.
+        """
+        last_step_finish_reason: str | None = None
         for event in reversed(agent_state.events):
             if event.event_type == "error":
                 return True
-            if event.event_type == "step_finish":
-                reason = event.raw.get("part", {}).get("reason", "")
-                return reason in ("stop", "error")
-        return False
+            if event.event_type == "step_finish" and last_step_finish_reason is None:
+                last_step_finish_reason = event.raw.get("part", {}).get("reason", "")
+        return last_step_finish_reason in ("stop", "error")
 
     def _update_agent_list(self) -> None:
         """Update the agent selector with current state."""

--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -3,6 +3,8 @@ Main Textual application for dlab connect TUI.
 """
 
 import json
+import logging
+import traceback
 from pathlib import Path
 
 from textual.app import App, ComposeResult
@@ -11,12 +13,9 @@ from textual.containers import Horizontal, Vertical
 from textual.timer import Timer
 from textual.widgets import Footer, Header, Static, TabbedContent, TabPane
 
-from dlab.timeline import (
-    discover_agents,
-    is_log_complete,
-)
+from dlab.timeline import is_log_complete
 from dlab.tui.log_watcher import LogWatcher
-from dlab.tui.models import LogEvent, SessionState
+from dlab.tui.models import AgentState, LogEvent, SessionState
 from dlab.tui.widgets.agent_list import AgentSelector
 from dlab.tui.widgets.artifacts_pane import ArtifactList, FileViewer
 from dlab.tui.widgets.log_view import LogView
@@ -204,11 +203,27 @@ class ConnectApp(App):
         self._state = SessionState(work_dir=work_dir)
         self._watcher: LogWatcher | None = None
         self._selected_agent: str | None = None
-        self._known_agents: set[str] = set()
         self._update_timer: Timer | None = None
         self._default_agent = load_default_agent(work_dir)
         self._search_matches: list[int] = []
         self._current_match_index: int = 0
+        self._logger = self._make_logger(work_dir)
+
+    @staticmethod
+    def _make_logger(work_dir: Path) -> logging.Logger:
+        """Create a file logger that writes to <work_dir>/.dlab_tui_debug.log."""
+        log_file = work_dir / ".dlab_tui_debug.log"
+        logger = logging.getLogger(f"dlab.tui.{log_file}")
+        logger.setLevel(logging.DEBUG)
+        if not logger.handlers:
+            handler = logging.FileHandler(log_file, mode="w", encoding="utf-8")
+            handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s %(levelname)-8s %(funcName)s: %(message)s"
+                )
+            )
+            logger.addHandler(handler)
+        return logger
 
     def compose(self) -> ComposeResult:
         """Create child widgets."""
@@ -233,31 +248,63 @@ class ConnectApp(App):
 
     async def on_mount(self) -> None:
         """Initialize on app mount."""
-        self.title = f"dlab connect - {self._work_dir.name}"
+        try:
+            await self._mount_impl()
+        except Exception:  # noqa: BLE001
+            crash_log = self._work_dir / ".dlab_tui_crash.log"
+            crash_log.write_text(traceback.format_exc())
+            # Show a visible error in the status bar so the UI isn't silently dead.
+            try:
+                status_bar = self.query_one("#status-bar", StatusBar)
+                status_bar.update_status(
+                    is_running=False,
+                    cost=0.0,
+                    duration=0.0,
+                    agent=f"INIT ERROR — see {crash_log.name}",
+                )
+            except Exception:
+                pass
+            # Still start the timer so the app remains interactive.
+            self._update_timer = self.set_interval(0.5, self._on_update_tick)
 
-        # Discover known agents
-        opencode_dir = self._work_dir / ".opencode"
-        if opencode_dir.exists():
-            self._known_agents = discover_agents(opencode_dir)
+    async def _mount_impl(self) -> None:
+        """Core mount logic — called by on_mount inside a try/except."""
+        self._logger.info("mount start | logs_dir=%s", self._logs_dir)
+        self.title = f"dlab connect - {self._work_dir.name}"
 
         # Check if job is running
         main_log = self._logs_dir / "main.log"
-        self._state.is_job_running = main_log.exists() and not is_log_complete(main_log)
+        self._logger.info("main.log exists=%s", main_log.exists())
+        try:
+            self._state.is_job_running = main_log.exists() and not is_log_complete(
+                main_log
+            )
+            self._logger.info("is_job_running=%s", self._state.is_job_running)
+        except Exception:
+            self._logger.exception("is_log_complete(main_log) failed")
+            self._state.is_job_running = True  # assume still running if we can't tell
 
         # Get global start timestamp from main.log FIRST
         # This is the authoritative reference for all relative timestamps
         self._state.global_start_ts = get_global_start_ts(self._logs_dir)
+        self._logger.info("global_start_ts=%s", self._state.global_start_ts)
 
         # Start log watcher
         self._watcher = LogWatcher(self._logs_dir)
         self._watcher.start()
+        initial_events = self._watcher.get_events()
+        self._logger.info("watcher.start() produced %d events", len(initial_events))
+        # Re-queue the events we just drained for inspection
+        for item in initial_events:
+            self._watcher._event_queue.put(item)
 
         # Process initial events
         self._process_pending_events()
-
-        # Select first agent
-        agent_selector = self.query_one("#agent-selector", AgentSelector)
-        agent_selector.select_first()
+        self._logger.info(
+            "after process_pending: %d agents, total_cost=%.4f",
+            len(self._state.agents),
+            self._state.total_cost,
+        )
 
         # Show placeholder in file viewer
         file_viewer = self.query_one("#file-viewer", FileViewer)
@@ -271,6 +318,7 @@ class ConnectApp(App):
 
         # Start periodic update timer
         self._update_timer = self.set_interval(0.5, self._on_update_tick)
+        self._logger.info("mount complete — timer started")
 
     async def on_unmount(self) -> None:
         """Cleanup on app unmount."""
@@ -324,7 +372,12 @@ class ConnectApp(App):
                     log_view.append_event(event)
 
         if events:
-            self._update_agent_list()
+            try:
+                self._update_agent_list()
+            except Exception:
+                self._logger.exception(
+                    "_update_agent_list failed (agents=%d)", len(self._state.agents)
+                )
             self._update_status_bar()
 
     def _get_log_path(self, display_name: str) -> Path:
@@ -354,6 +407,16 @@ class ConnectApp(App):
 
         return log_path
 
+    def _is_agent_complete_in_memory(self, agent_state: AgentState) -> bool:
+        """Check completion from already-loaded events — no disk I/O."""
+        for event in reversed(agent_state.events):
+            if event.event_type == "error":
+                return True
+            if event.event_type == "step_finish":
+                reason = event.raw.get("part", {}).get("reason", "")
+                return reason in ("stop", "error")
+        return False
+
     def _update_agent_list(self) -> None:
         """Update the agent selector with current state."""
         agent_selector = self.query_one("#agent-selector", AgentSelector)
@@ -371,22 +434,22 @@ class ConnectApp(App):
 
         # Check if main agent is complete — if so, all sub-agents are done
         # (sub-agents may lack a clean stop event if the container was killed).
-        # Cache the result on AgentState so we never re-parse a completed file.
-        main_log = self._get_log_path("main")
+        # Uses in-memory events; no disk I/O.
         main_agent_state = self._state.agents.get(main_display_name)
         if main_agent_state and main_agent_state.is_complete:
             main_complete = True
-        else:
-            main_complete = main_log.exists() and is_log_complete(main_log)
-            if main_complete and main_agent_state:
+        elif main_agent_state is not None:
+            main_complete = self._is_agent_complete_in_memory(main_agent_state)
+            if main_complete:
                 main_agent_state.is_complete = True
+        else:
+            main_complete = False
 
         if not main_complete:
             for name in self._state.agents.keys():
                 agent_state = self._state.agents[name]
                 if not agent_state.is_complete:
-                    log_path = self._get_log_path(name)
-                    if log_path.exists() and is_log_complete(log_path):
+                    if self._is_agent_complete_in_memory(agent_state):
                         agent_state.is_complete = True
                 if not agent_state.is_complete:
                     running.add(name)
@@ -413,18 +476,25 @@ class ConnectApp(App):
         )
 
     def _on_update_tick(self) -> None:
-        """Periodic update tick."""
-        # Poll log files directly as fallback for unreliable watchdog events
-        # (especially on macOS where FSEvents can miss Docker/atomic writes)
-        if self._watcher:
-            self._watcher.poll()
+        """Periodic update tick — all sub-calls are guarded so one failure never kills the timer."""
+        try:
+            if self._watcher:
+                self._watcher.poll()
+            self._process_pending_events()
+        except Exception:
+            self._logger.exception("_on_update_tick: poll/process failed")
 
-        self._process_pending_events()
-        self._update_status_bar()
+        # Always refresh status bar so the UI doesn't freeze if process_pending throws.
+        try:
+            self._update_status_bar()
+        except Exception:
+            self._logger.exception("_on_update_tick: _update_status_bar failed")
 
-        # Refresh artifacts periodically (detect new files created during execution)
-        artifact_list = self.query_one("#artifact-list", ArtifactList)
-        artifact_list.refresh_if_changed()
+        try:
+            artifact_list = self.query_one("#artifact-list", ArtifactList)
+            artifact_list.refresh_if_changed()
+        except Exception:
+            self._logger.exception("_on_update_tick: artifact refresh failed")
 
     def on_agent_selector_agent_selected(
         self, event: AgentSelector.AgentSelected

--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -6,22 +6,22 @@ import json
 from pathlib import Path
 
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Header, Footer, Static, TabbedContent, TabPane
 from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
 from textual.timer import Timer
+from textual.widgets import Footer, Header, Static, TabbedContent, TabPane
 
-from dlab.tui.widgets.agent_list import AgentSelector
-from dlab.tui.widgets.log_view import LogView
-from dlab.tui.widgets.status_bar import StatusBar
-from dlab.tui.widgets.artifacts_pane import ArtifactList, FileViewer
-from dlab.tui.widgets.search_popup import SearchPopup
-from dlab.tui.log_watcher import LogWatcher
-from dlab.tui.models import SessionState, LogEvent
 from dlab.timeline import (
-    is_log_complete,
     discover_agents,
+    is_log_complete,
 )
+from dlab.tui.log_watcher import LogWatcher
+from dlab.tui.models import LogEvent, SessionState
+from dlab.tui.widgets.agent_list import AgentSelector
+from dlab.tui.widgets.artifacts_pane import ArtifactList, FileViewer
+from dlab.tui.widgets.log_view import LogView
+from dlab.tui.widgets.search_popup import SearchPopup
+from dlab.tui.widgets.status_bar import StatusBar
 
 
 def load_default_agent(work_dir: Path) -> str | None:
@@ -386,6 +386,13 @@ class ConnectApp(App):
         agent_selector.update_agents(agents, running)
 
         self._state.is_job_running = main_display_name in running
+
+        # Auto-select the first agent if nothing is selected yet.
+        # This handles live sessions where main.log may be empty at startup
+        # so select_first() in on_mount was a no-op, and agents only appear
+        # once the first timer tick reads new log content.
+        if self._selected_agent is None and agents:
+            agent_selector.select_first()
 
     def _update_status_bar(self) -> None:
         """Update the status bar."""

--- a/dlab/tui/log_watcher.py
+++ b/dlab/tui/log_watcher.py
@@ -36,6 +36,8 @@ class LogWatcher:
         self._file_inodes: dict[Path, int] = {}  # Track inode for replacement detection
         self._lock = threading.Lock()
         self._running = False
+        self._known_log_paths: list[Path] = []
+        self._logs_dir_mtime: float = 0.0
 
     def _get_source_name(self, log_path: Path) -> str:
         """
@@ -173,6 +175,19 @@ class LogWatcher:
         """Stop watching."""
         self._running = False
 
+    def _refresh_log_paths(self) -> None:
+        """Re-scan for log files only when the directory tree has changed."""
+        try:
+            current_mtime = self._logs_dir.stat().st_mtime
+        except OSError:
+            return
+        if current_mtime != self._logs_dir_mtime:
+            try:
+                self._known_log_paths = list(self._logs_dir.rglob("*.log"))
+            except (PermissionError, OSError):
+                pass
+            self._logs_dir_mtime = current_mtime
+
     def poll(self) -> None:
         """
         Poll all log files for new content.
@@ -182,11 +197,8 @@ class LogWatcher:
         if not self._running:
             return
 
-        try:
-            log_paths = list(self._logs_dir.rglob("*.log"))
-        except (PermissionError, OSError):
-            log_paths = []
-        for log_path in log_paths:
+        self._refresh_log_paths()
+        for log_path in self._known_log_paths:
             for source, event in self._read_new_lines(log_path):
                 self._event_queue.put((source, event))
 

--- a/dlab/tui/log_watcher.py
+++ b/dlab/tui/log_watcher.py
@@ -4,6 +4,7 @@ Log file watcher using simple polling.
 Tracks file positions and streams new log events as they are appended.
 """
 
+import os
 import threading
 from pathlib import Path
 from queue import Queue
@@ -175,10 +176,28 @@ class LogWatcher:
         """Stop watching."""
         self._running = False
 
+    def _logs_dir_signature(self) -> float:
+        """Latest mtime across every directory in the log tree.
+
+        Sub-agent logs live in subdirectories (``_opencode_logs/<agent>/...``),
+        so watching only the top-level mtime would miss a new ``.log`` file
+        created inside an already-known subdirectory — e.g. a late-spawning
+        nested agent. Adding a file bumps its *containing* directory's mtime,
+        so taking the max mtime over all directories in the tree detects that.
+        Walking directories (not stat-ing every file) keeps this cheap.
+        """
+        signature = self._logs_dir.stat().st_mtime
+        for dirpath, _dirnames, _filenames in os.walk(self._logs_dir):
+            try:
+                signature = max(signature, os.stat(dirpath).st_mtime)
+            except OSError:
+                continue
+        return signature
+
     def _refresh_log_paths(self) -> None:
         """Re-scan for log files only when the directory tree has changed."""
         try:
-            current_mtime = self._logs_dir.stat().st_mtime
+            current_mtime = self._logs_dir_signature()
         except OSError:
             return
         if current_mtime != self._logs_dir_mtime:

--- a/dlab/tui/log_watcher.py
+++ b/dlab/tui/log_watcher.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from queue import Queue
 from typing import Any, Callable
 
-from dlab.opencode_logparser import LogEvent as ParsedEvent, parse_line
+from dlab.opencode_logparser import LogEvent as ParsedEvent
+from dlab.opencode_logparser import parse_line
 
 
 class LogWatcher:
@@ -156,8 +157,13 @@ class LogWatcher:
         if self._running:
             return
 
-        # Read existing content
-        for log_path in self._logs_dir.rglob("*.log"):
+        # Read existing content; guard against permission errors on unreadable
+        # subdirectories (e.g. Docker-owned dirs when running as a regular user).
+        try:
+            log_paths = list(self._logs_dir.rglob("*.log"))
+        except (PermissionError, OSError):
+            log_paths = []
+        for log_path in log_paths:
             for source, event in self._read_new_lines(log_path):
                 self._event_queue.put((source, event))
 
@@ -176,7 +182,11 @@ class LogWatcher:
         if not self._running:
             return
 
-        for log_path in self._logs_dir.rglob("*.log"):
+        try:
+            log_paths = list(self._logs_dir.rglob("*.log"))
+        except (PermissionError, OSError):
+            log_paths = []
+        for log_path in log_paths:
             for source, event in self._read_new_lines(log_path):
                 self._event_queue.put((source, event))
 

--- a/dlab/tui/models.py
+++ b/dlab/tui/models.py
@@ -44,7 +44,7 @@ class LogEvent:
     raw: dict[str, Any]
     cost: float = 0.0
     duration_ms: int | None = None
-    hidden: bool = False    # True for step_start/step_finish (not rendered)
+    hidden: bool = False  # True for step_start/step_finish (not rendered)
 
     @property
     def full_description(self) -> str:
@@ -342,6 +342,11 @@ class AgentState:
         Start time of first event.
     end_time : datetime | None
         End time of last event.
+    is_complete : bool
+        Cached flag: True once the agent's log file has been confirmed complete.
+        Avoids re-parsing the entire log file on every timer tick.
+    _seen_timestamps : set[int]
+        Set of already-seen timestamps for O(1) duplicate detection.
     """
 
     name: str
@@ -350,6 +355,8 @@ class AgentState:
     total_cost: float = 0.0
     start_time: datetime | None = None
     end_time: datetime | None = None
+    is_complete: bool = False
+    _seen_timestamps: set[int] = field(default_factory=set, repr=False, compare=False)
 
     def add_event(self, event: LogEvent) -> bool:
         """
@@ -368,10 +375,13 @@ class AgentState:
         bool
             True if event was added, False if it was a duplicate.
         """
-        # Deduplicate based on timestamp (events with same timestamp are duplicates)
-        # Skip deduplication for timestamp=0 events (raw_text, additional_output)
-        if event.timestamp > 0 and any(e.timestamp == event.timestamp for e in self.events):
-            return False
+        # Deduplicate based on timestamp (events with same timestamp are duplicates).
+        # Skip deduplication for timestamp=0 events (raw_text, additional_output).
+        # O(1) set lookup instead of O(n) linear scan.
+        if event.timestamp > 0:
+            if event.timestamp in self._seen_timestamps:
+                return False
+            self._seen_timestamps.add(event.timestamp)
 
         self.events.append(event)
         self.total_cost += event.cost
@@ -428,9 +438,7 @@ class SessionState:
         start_dt = ms_to_datetime(self.global_start_ts)
 
         # Find latest end time from all agents (from log timestamps only)
-        end_times = [
-            a.end_time for a in self.agents.values() if a.end_time is not None
-        ]
+        end_times = [a.end_time for a in self.agents.values() if a.end_time is not None]
         if end_times:
             end_dt = max(end_times)
         else:

--- a/dlab/tui/widgets/artifacts_pane.py
+++ b/dlab/tui/widgets/artifacts_pane.py
@@ -8,24 +8,41 @@ Provides:
 
 import csv
 import io
+import os
 import re
 from pathlib import Path
 
-from textual.widgets import ListView, ListItem, Static, DataTable
-from textual.containers import VerticalScroll
-from textual.reactive import reactive
-from textual.message import Message
-from rich.text import Text
+from rich.console import Group
 from rich.markdown import Markdown
 from rich.syntax import Syntax
-from rich.console import Group
-
+from rich.text import Text
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widgets import DataTable, ListItem, ListView, Static
 
 # File extensions to include as artifacts
 ARTIFACT_EXTENSIONS = {".md", ".py", ".txt", ".csv", ".png", ".jpg", ".jpeg", ".pdf"}
 
 # Directories to exclude from artifact discovery
-EXCLUDE_DIRS = {".git", ".opencode", "_opencode_logs", "_docker", "_hooks", "node_modules", "__pycache__", "data"}
+EXCLUDE_DIRS = {
+    ".git",
+    ".opencode",
+    "_opencode_logs",
+    "_docker",
+    "_hooks",
+    "node_modules",
+    "__pycache__",
+    "data",
+    ".venv",
+    "venv",
+    ".env",
+    "env",
+    "dist",
+    "build",
+    ".tox",
+    ".mypy_cache",
+}
 
 # Image extensions
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
@@ -115,35 +132,32 @@ def discover_artifacts(
     list[Path]
         List of artifact paths relative to work_dir.
     """
-    artifacts: list[Path] = []
     search_dir = agent_dir if agent_dir else work_dir
-
     if not search_dir.exists():
-        return artifacts
+        return []
 
-    for path in search_dir.rglob("*"):
-        if not path.is_file():
-            continue
+    artifacts: list[Path] = []
+    base = agent_dir if agent_dir else work_dir
 
-        # Skip excluded directories
-        if any(excluded in path.parts for excluded in EXCLUDE_DIRS):
-            continue
+    for root, dirs, files in os.walk(search_dir, topdown=True):
+        root_path = Path(root)
 
-        # For main agent, skip files inside parallel run directories
-        if is_main and any(is_parallel_run_dir(part) for part in path.parts):
-            continue
+        # Prune excluded and parallel-run directories in-place so os.walk
+        # never descends into them — O(relevant files only).
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in EXCLUDE_DIRS and not (is_main and is_parallel_run_dir(d))
+        ]
 
-        # Check extension
-        if path.suffix.lower() not in ARTIFACT_EXTENSIONS:
-            continue
-
-        # Store relative path (relative to agent_dir for subagents, work_dir for main)
-        base = agent_dir if agent_dir else work_dir
-        try:
-            rel_path = path.relative_to(base)
-            artifacts.append(rel_path)
-        except ValueError:
-            artifacts.append(path)
+        for filename in files:
+            file_path = root_path / filename
+            if file_path.suffix.lower() not in ARTIFACT_EXTENSIONS:
+                continue
+            try:
+                artifacts.append(file_path.relative_to(base))
+            except ValueError:
+                artifacts.append(file_path)
 
     return sorted(artifacts)
 
@@ -184,7 +198,7 @@ class ArtifactItem(ListItem):
 
         max_len: int = 19
         if len(display_path) > max_len:
-            display_path = display_path[:max_len - 1] + "…"
+            display_path = display_path[: max_len - 1] + "…"
 
         text = Text()
         text.append(f"{tag:>3}", style="dim")
@@ -193,8 +207,11 @@ class ArtifactItem(ListItem):
 
 
 _ARTIFACT_TYPE_ORDER: dict[str, int] = {
-    ".md": 0, ".py": 1,
-    ".png": 2, ".jpg": 2, ".jpeg": 2,
+    ".md": 0,
+    ".py": 1,
+    ".png": 2,
+    ".jpg": 2,
+    ".jpeg": 2,
     ".csv": 3,
 }
 
@@ -239,7 +256,9 @@ class ArtifactList(ListView):
         is_main = agent_name is not None and agent_name.startswith("main")
 
         # Discover artifacts
-        self._artifacts = discover_artifacts(self._work_dir, self._agent_dir, is_main=is_main)
+        self._artifacts = discover_artifacts(
+            self._work_dir, self._agent_dir, is_main=is_main
+        )
 
         # Rebuild list
         self.clear()
@@ -260,7 +279,9 @@ class ArtifactList(ListView):
 
         self._agent_dir = get_agent_directory(self._work_dir, self._agent_name)
         is_main = self._agent_name.startswith("main")
-        new_artifacts = _sort_artifacts(discover_artifacts(self._work_dir, self._agent_dir, is_main=is_main))
+        new_artifacts = _sort_artifacts(
+            discover_artifacts(self._work_dir, self._agent_dir, is_main=is_main)
+        )
 
         if new_artifacts != self._artifacts:
             self._artifacts = new_artifacts
@@ -284,7 +305,9 @@ class ArtifactList(ListView):
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Handle selection (Enter key)."""
         if isinstance(event.item, ArtifactItem):
-            self.post_message(self.FileSelected(self._resolve_path(event.item.file_path)))
+            self.post_message(
+                self.FileSelected(self._resolve_path(event.item.file_path))
+            )
 
     def get_highlighted_path(self) -> Path | None:
         """Get the path of the currently highlighted file."""
@@ -630,7 +653,12 @@ class CsvDisplay(DataTable):
             # Show truncation message if needed
             if len(rows) > self._max_rows + 1:
                 truncated = len(rows) - self._max_rows - 1
-                self.add_row(*[f"... {truncated} more rows ..." if i == 0 else "" for i in range(len(headers))])
+                self.add_row(
+                    *[
+                        f"... {truncated} more rows ..." if i == 0 else ""
+                        for i in range(len(headers))
+                    ]
+                )
 
         except csv.Error:
             # Fallback to plain text display if CSV parsing fails

--- a/dlab/tui/widgets/log_view.py
+++ b/dlab/tui/widgets/log_view.py
@@ -5,16 +5,15 @@ Displays formatted log events for the selected agent with
 real-time updates and expand/collapse functionality.
 """
 
-from textual.widgets import Static
-from textual.containers import VerticalScroll, Horizontal
-from textual.reactive import reactive
-from textual import events
-from rich.text import Text
-from rich.markdown import Markdown
 from rich.console import Group
+from rich.markdown import Markdown
+from rich.text import Text
+from textual import events
+from textual.containers import Horizontal, VerticalScroll
+from textual.reactive import reactive
+from textual.widgets import Static
 
 from dlab.tui.models import LogEvent
-
 
 # Monokai-native color palette
 _CYAN: str = "#66D9EF"
@@ -413,12 +412,16 @@ class LogView(VerticalScroll, can_focus=True):
         self.remove_children()
         self._widgets = []
 
+        widgets = []
         for event in self._events:
             if event.hidden:
                 continue
             widget = LogEventWidget(event, self._global_start_ts)
             self._widgets.append(widget)
-            self.mount(widget)
+            widgets.append(widget)
+
+        if widgets:
+            self.mount(*widgets)
 
         if self.auto_scroll:
             self.scroll_end(animate=False)
@@ -460,7 +463,10 @@ class LogView(VerticalScroll, can_focus=True):
             vp_top: int = self.scroll_offset.y
             vp_bottom: int = vp_top + self.size.height
             try:
-                if w.virtual_region.y < vp_bottom and w.virtual_region.y + w.virtual_region.height > vp_top:
+                if (
+                    w.virtual_region.y < vp_bottom
+                    and w.virtual_region.y + w.virtual_region.height > vp_top
+                ):
                     return  # Already visible
             except Exception:
                 return
@@ -496,9 +502,7 @@ class LogView(VerticalScroll, can_focus=True):
             widget.is_collapsed = False
         self.refresh(layout=True)
         if 0 <= self.selected_index < len(self._widgets):
-            self.call_after_refresh(
-                self._widgets[self.selected_index].scroll_visible
-            )
+            self.call_after_refresh(self._widgets[self.selected_index].scroll_visible)
 
     def collapse_all(self) -> None:
         """Collapse all collapsible events."""
@@ -508,9 +512,7 @@ class LogView(VerticalScroll, can_focus=True):
             widget.is_collapsed = True
         self.refresh(layout=True)
         if 0 <= self.selected_index < len(self._widgets):
-            self.call_after_refresh(
-                self._widgets[self.selected_index].scroll_visible
-            )
+            self.call_after_refresh(self._widgets[self.selected_index].scroll_visible)
 
     def highlight_search(self, query: str) -> list[int]:
         """

--- a/tests/test_tui_render_followups.py
+++ b/tests/test_tui_render_followups.py
@@ -1,0 +1,101 @@
+"""Regression tests for the TUI render/perf fixes in the connect-tui-render-faster PR.
+
+Covers the pure-ish helpers that back the performance and correctness fixes:
+- ``AgentState.add_event`` O(1) timestamp dedup
+- ``discover_artifacts`` directory pruning (notably ``.venv``)
+- ``ConnectApp._is_agent_complete_in_memory`` matching ``is_log_complete`` semantics
+"""
+
+from pathlib import Path
+
+from dlab.tui.app import ConnectApp
+from dlab.tui.models import AgentState, LogEvent
+from dlab.tui.widgets.artifacts_pane import discover_artifacts
+
+
+def _event(timestamp: int, event_type: str, **part: object) -> LogEvent:
+    """Build a TUI LogEvent from a raw dict the way the watcher does."""
+    raw: dict[str, object] = {"timestamp": timestamp, "type": event_type}
+    if part:
+        raw["part"] = part
+    return LogEvent.from_raw(raw, source="agent")
+
+
+class TestAddEventDedup:
+    """AgentState.add_event deduplicates by timestamp via the _seen set."""
+
+    def test_duplicate_timestamp_rejected(self) -> None:
+        state = AgentState(name="agent")
+        assert state.add_event(_event(100, "text", text="a")) is True
+        # Same timestamp -> treated as a duplicate, not added again.
+        assert state.add_event(_event(100, "text", text="b")) is False
+        assert len(state.events) == 1
+
+    def test_distinct_timestamps_kept(self) -> None:
+        state = AgentState(name="agent")
+        assert state.add_event(_event(100, "text", text="a")) is True
+        assert state.add_event(_event(200, "text", text="b")) is True
+        assert len(state.events) == 2
+
+    def test_zero_timestamp_never_deduped(self) -> None:
+        # timestamp=0 events (raw_text / additional_output) must always be added.
+        state = AgentState(name="agent")
+        assert state.add_event(_event(0, "raw_text", text="x")) is True
+        assert state.add_event(_event(0, "raw_text", text="y")) is True
+        assert len(state.events) == 2
+
+
+class TestDiscoverArtifactsPruning:
+    """discover_artifacts excludes heavy/irrelevant directories."""
+
+    def test_venv_is_pruned(self, tmp_path: Path) -> None:
+        (tmp_path / "report.md").write_text("real artifact")
+        venv = tmp_path / ".venv" / "lib"
+        venv.mkdir(parents=True)
+        (venv / "buried.py").write_text("should be ignored")
+
+        found = discover_artifacts(tmp_path, agent_dir=None)
+
+        assert Path("report.md") in found
+        assert all(".venv" not in p.parts for p in found)
+
+    def test_other_excluded_dirs_pruned(self, tmp_path: Path) -> None:
+        (tmp_path / "keep.csv").write_text("a,b")
+        for excluded in ("node_modules", "__pycache__", "build", ".git"):
+            d = tmp_path / excluded
+            d.mkdir()
+            (d / "junk.py").write_text("x")
+
+        found = discover_artifacts(tmp_path, agent_dir=None)
+
+        assert Path("keep.csv") in found
+        assert found == [Path("keep.csv")]
+
+
+class TestInMemoryCompletion:
+    """_is_agent_complete_in_memory mirrors is_log_complete semantics."""
+
+    @staticmethod
+    def _complete(events: list[LogEvent]) -> bool:
+        # The method does not touch self, so an unbound call with None is safe.
+        state = AgentState(name="agent", events=events)
+        return ConnectApp._is_agent_complete_in_memory(None, state)  # type: ignore[arg-type]
+
+    def test_stop_step_finish_is_complete(self) -> None:
+        assert self._complete([_event(100, "step_finish", reason="stop")]) is True
+
+    def test_running_step_finish_not_complete(self) -> None:
+        assert self._complete([_event(100, "step_finish", reason="tool_use")]) is False
+
+    def test_error_takes_priority_over_later_step_finish(self) -> None:
+        # An error earlier in the list must still mark the agent complete even if
+        # the final step_finish has a non-terminal reason (matches is_log_complete,
+        # which gives any error event priority).
+        events = [
+            _event(100, "error"),
+            _event(200, "step_finish", reason="tool_use"),
+        ]
+        assert self._complete(events) is True
+
+    def test_no_terminal_events_not_complete(self) -> None:
+        assert self._complete([_event(100, "text", text="hi")]) is False


### PR DESCRIPTION
executive summary: It was taking the TUI so longer to render that it looked like it was broken. For the mmm-example, it spawned 10 agent instances, each with their own, very long logs. Sections of the TUI would populate after 10 minutes or so. A few other errors would crash the TUI too:

before:
<img width="581" height="348" alt="Screenshot 2026-05-25 182244" src="https://github.com/user-attachments/assets/2bed8c81-de08-47ad-a07c-6807d389ba43" />

after:
<img width="587" height="479" alt="image" src="https://github.com/user-attachments/assets/19d3871b-3c1e-4bfd-aade-11a0c62ff4a7" />



---

## Context

`dlab connect` is a Textual TUI that attaches to a running or completed job and streams its logs,
agent activity, and output files in real time. These changes fix several bugs that caused the UI to
render a shell but leave all panes permanently empty, or stall for 10–35 minutes before populating.

---

## Bugs fixed

### 1. Unguarded `rglob` in `LogWatcher.start()` silently killed the entire UI

`LogWatcher.start()` called `self._logs_dir.rglob("*.log")` with no error handling. On systems
where the log directory contains Docker-owned subdirectories, this raised `PermissionError`.
Because Textual silently swallows exceptions from async lifecycle methods, the exception propagated
out of `on_mount` undetected — and the `set_interval` call that starts the update timer was never
reached. The result was a UI that rendered its layout but never received a single update tick,
leaving every pane empty indefinitely.

The fix wraps the `rglob` call in `try/except (PermissionError, OSError)` and falls back to an
empty list. The redundant `watcher.poll()` call immediately after `start()` (which re-walked the
same files with already-advanced read positions, producing nothing) was also removed.

**Files**: `dlab/tui/log_watcher.py`, `dlab/tui/app.py`

---

### 2. `on_mount` crash now produces a visible error instead of a frozen UI

As a structural fix for the class of bug above, `on_mount` now wraps its implementation in a
`try/except`. On failure it writes a full traceback to `.dlab_tui_crash.log`, displays an error
message in the status bar, and still starts the update timer so the app remains responsive. A
`_file_logger` writing to `.dlab_tui_debug.log` was also added to make future mount failures
diagnosable without attaching a debugger.

**File**: `dlab/tui/app.py`

---

### 3. `discover_artifacts` traversed a 1.3 GB `.venv` tree on every 500 ms tick

`discover_artifacts` used `Path.rglob("*")` to find output files, applying the exclusion list
only after descending into each directory. `.venv` was absent from the exclusion list, so every
tick walked the full virtual-environment tree before discarding everything it found. On the target
environment (11 parallel agent instances, each with a 1.3 GB `.venv`) this produced a ~35-second
synchronous call on the asyncio event-loop thread — completely freezing keyboard input, log
polling, and rendering for the duration.

Two changes fix this:

- `.venv`, `venv`, `.env`, `env`, `dist`, `build`, `.tox`, and `.mypy_cache` added to `EXCLUDE_DIRS`.
- `rglob` replaced with `os.walk(topdown=True)`, pruning excluded directories in-place via
  `dirs[:] = [...]` so `os.walk` never descends into them.

**File**: `dlab/tui/widgets/artifacts_pane.py`

---

### 4. `is_log_file_complete` re-read and re-parsed entire log files on every tick

To determine whether an agent had finished, `_update_agent_list` called `is_log_file_complete(path)`
for the main log and for every still-running agent on every 500 ms tick. This function opens the
file and parses every JSON line from scratch each call. For long-running sessions with megabyte-scale
logs and many agents, the cumulative I/O and parse time (measured at 9–470 ms per tick depending
on OS cache warmth) made the UI visibly sluggish.

The fix replaces the disk-based check with `_is_agent_complete_in_memory()`, which scans
`AgentState.events` in reverse for a terminal `step_finish` or `error` event — all data already
in memory with zero I/O. The result is cached on `AgentState.is_complete` so even the in-memory
scan runs at most once per agent.

**Files**: `dlab/tui/app.py`, `dlab/tui/models.py`

---

### 5. O(n²) duplicate detection in `AgentState.add_event`

`add_event` deduplicated events by scanning the entire `self.events` list for a matching timestamp
on every insertion. For the initial load of a long session (potentially thousands of events), this
was quadratic — tens of millions of comparisons before the UI became interactive.

Fixed by adding a `_seen_timestamps: set[int]` field to `AgentState` and replacing the linear scan
with an O(1) set lookup.

**File**: `dlab/tui/models.py`

---

### 6. `rglob("*.log")` in `poll()` rescanned the filesystem on every tick

`LogWatcher.poll()` called `rglob("*.log")` on every 500 ms tick to discover log files, even when
no new files had been created. The fix caches the discovered paths and only re-scans when the
directory's `mtime` advances.

**File**: `dlab/tui/log_watcher.py`

---

### 7. Duplicate `select_first()` caused a double widget rebuild on startup

`on_mount` called `agent_selector.select_first()` explicitly, and `_update_agent_list` called it
again whenever `_selected_agent is None` and agents were present. On startup both fired in quick
succession, triggering two full `_rebuild_widgets` cycles — the second clearing `self._widgets`
synchronously while the first `mount()` call was still queued, and `scroll_end` firing before any
widgets were mounted.

The explicit call was removed from `on_mount`; `_update_agent_list` is the single owner of
auto-selection. The `select_first()` call there was also moved to the live-session path, which
handles the case where `main.log` is empty at startup and agents only appear after the first tick.

**File**: `dlab/tui/app.py`

---

### 8. `_known_agents` was populated but never read

`on_mount` called `discover_agents()` and stored the result in `self._known_agents`, which was
never referenced again. The agent list was built entirely from events received by the log watcher.
The field, the import, and the call were removed.

**File**: `dlab/tui/app.py`

---

### 9. `LogView` mounted widgets one at a time

`_rebuild_widgets` called `self.mount(widget)` in a loop, issuing one Textual mount message per
event. Replaced with a single `self.mount(*widgets)` call.

**File**: `dlab/tui/widgets/log_view.py`

---

## Flagged: drain/re-queue pattern in `_mount_impl`

```python
initial_events = self._watcher.get_events()
self._file_logger.info("watcher.start() produced %d events", len(initial_events))
for item in initial_events:
    self._watcher._event_queue.put(item)
self._process_pending_events()
```

The queue is drained to log the count, then every item is pushed back through the private
`_watcher._event_queue` attribute before `_process_pending_events` drains it again. This works but
reaches into a private field and makes two passes through all startup events. A `qsize()` method
on `LogWatcher` would be cleaner.
