### PR TITLE
Address connect-tui review: rescan signature, mount cleanup, completion semantics

### DIFF
--- a/dlab/tui/app.py
+++ b/dlab/tui/app.py
@@ -292,13 +292,9 @@ class ConnectApp(App):
         # Start log watcher
         self._watcher = LogWatcher(self._logs_dir)
         self._watcher.start()
-        initial_events = self._watcher.get_events()
-        self._file_logger.info("watcher.start() produced %d events", len(initial_events))
-        # Re-queue the events we just drained for inspection
-        for item in initial_events:
-            self._watcher._event_queue.put(item)
 
-        # Process initial events
+        # Process the initial events produced by start(). _process_pending_events
+        # drains the watcher queue itself, so we must not drain it first here.
         self._process_pending_events()
         self._file_logger.info(
             "after process_pending: %d agents, total_cost=%.4f",
@@ -408,14 +404,21 @@ class ConnectApp(App):
         return log_path
 
     def _is_agent_complete_in_memory(self, agent_state: AgentState) -> bool:
-        """Check completion from already-loaded events — no disk I/O."""
+        """Check completion from already-loaded events — no disk I/O.
+
+        Mirrors ``is_log_complete``: any ``error`` event means complete, and
+        that takes priority over the final ``step_finish`` reason. We therefore
+        scan the whole list for an error rather than returning on the first
+        terminal event, while still using the last ``step_finish`` (first one
+        seen when iterating in reverse) for the reason check.
+        """
+        last_step_finish_reason: str | None = None
         for event in reversed(agent_state.events):
             if event.event_type == "error":
                 return True
-            if event.event_type == "step_finish":
-                reason = event.raw.get("part", {}).get("reason", "")
-                return reason in ("stop", "error")
-        return False
+            if event.event_type == "step_finish" and last_step_finish_reason is None:
+                last_step_finish_reason = event.raw.get("part", {}).get("reason", "")
+        return last_step_finish_reason in ("stop", "error")
 
     def _update_agent_list(self) -> None:
         """Update the agent selector with current state."""

--- a/dlab/tui/log_watcher.py
+++ b/dlab/tui/log_watcher.py
@@ -4,6 +4,7 @@ Log file watcher using simple polling.
 Tracks file positions and streams new log events as they are appended.
 """
 
+import os
 import threading
 from pathlib import Path
 from queue import Queue
@@ -175,10 +176,28 @@ class LogWatcher:
         """Stop watching."""
         self._running = False
 
+    def _logs_dir_signature(self) -> float:
+        """Latest mtime across every directory in the log tree.
+
+        Sub-agent logs live in subdirectories (``_opencode_logs/<agent>/...``),
+        so watching only the top-level mtime would miss a new ``.log`` file
+        created inside an already-known subdirectory — e.g. a late-spawning
+        nested agent. Adding a file bumps its *containing* directory's mtime,
+        so taking the max mtime over all directories in the tree detects that.
+        Walking directories (not stat-ing every file) keeps this cheap.
+        """
+        signature = self._logs_dir.stat().st_mtime
+        for dirpath, _dirnames, _filenames in os.walk(self._logs_dir):
+            try:
+                signature = max(signature, os.stat(dirpath).st_mtime)
+            except OSError:
+                continue
+        return signature
+
     def _refresh_log_paths(self) -> None:
         """Re-scan for log files only when the directory tree has changed."""
         try:
-            current_mtime = self._logs_dir.stat().st_mtime
+            current_mtime = self._logs_dir_signature()
         except OSError:
             return
         if current_mtime != self._logs_dir_mtime:

--- a/tests/test_tui_render_followups.py
+++ b/tests/test_tui_render_followups.py
@@ -1,0 +1,101 @@
+"""Regression tests for the TUI render/perf fixes in the connect-tui-render-faster PR.
+
+Covers the pure-ish helpers that back the performance and correctness fixes:
+- ``AgentState.add_event`` O(1) timestamp dedup
+- ``discover_artifacts`` directory pruning (notably ``.venv``)
+- ``ConnectApp._is_agent_complete_in_memory`` matching ``is_log_complete`` semantics
+"""
+
+from pathlib import Path
+
+from dlab.tui.app import ConnectApp
+from dlab.tui.models import AgentState, LogEvent
+from dlab.tui.widgets.artifacts_pane import discover_artifacts
+
+
+def _event(timestamp: int, event_type: str, **part: object) -> LogEvent:
+    """Build a TUI LogEvent from a raw dict the way the watcher does."""
+    raw: dict[str, object] = {"timestamp": timestamp, "type": event_type}
+    if part:
+        raw["part"] = part
+    return LogEvent.from_raw(raw, source="agent")
+
+
+class TestAddEventDedup:
+    """AgentState.add_event deduplicates by timestamp via the _seen set."""
+
+    def test_duplicate_timestamp_rejected(self) -> None:
+        state = AgentState(name="agent")
+        assert state.add_event(_event(100, "text", text="a")) is True
+        # Same timestamp -> treated as a duplicate, not added again.
+        assert state.add_event(_event(100, "text", text="b")) is False
+        assert len(state.events) == 1
+
+    def test_distinct_timestamps_kept(self) -> None:
+        state = AgentState(name="agent")
+        assert state.add_event(_event(100, "text", text="a")) is True
+        assert state.add_event(_event(200, "text", text="b")) is True
+        assert len(state.events) == 2
+
+    def test_zero_timestamp_never_deduped(self) -> None:
+        # timestamp=0 events (raw_text / additional_output) must always be added.
+        state = AgentState(name="agent")
+        assert state.add_event(_event(0, "raw_text", text="x")) is True
+        assert state.add_event(_event(0, "raw_text", text="y")) is True
+        assert len(state.events) == 2
+
+
+class TestDiscoverArtifactsPruning:
+    """discover_artifacts excludes heavy/irrelevant directories."""
+
+    def test_venv_is_pruned(self, tmp_path: Path) -> None:
+        (tmp_path / "report.md").write_text("real artifact")
+        venv = tmp_path / ".venv" / "lib"
+        venv.mkdir(parents=True)
+        (venv / "buried.py").write_text("should be ignored")
+
+        found = discover_artifacts(tmp_path, agent_dir=None)
+
+        assert Path("report.md") in found
+        assert all(".venv" not in p.parts for p in found)
+
+    def test_other_excluded_dirs_pruned(self, tmp_path: Path) -> None:
+        (tmp_path / "keep.csv").write_text("a,b")
+        for excluded in ("node_modules", "__pycache__", "build", ".git"):
+            d = tmp_path / excluded
+            d.mkdir()
+            (d / "junk.py").write_text("x")
+
+        found = discover_artifacts(tmp_path, agent_dir=None)
+
+        assert Path("keep.csv") in found
+        assert found == [Path("keep.csv")]
+
+
+class TestInMemoryCompletion:
+    """_is_agent_complete_in_memory mirrors is_log_complete semantics."""
+
+    @staticmethod
+    def _complete(events: list[LogEvent]) -> bool:
+        # The method does not touch self, so an unbound call with None is safe.
+        state = AgentState(name="agent", events=events)
+        return ConnectApp._is_agent_complete_in_memory(None, state)  # type: ignore[arg-type]
+
+    def test_stop_step_finish_is_complete(self) -> None:
+        assert self._complete([_event(100, "step_finish", reason="stop")]) is True
+
+    def test_running_step_finish_not_complete(self) -> None:
+        assert self._complete([_event(100, "step_finish", reason="tool_use")]) is False
+
+    def test_error_takes_priority_over_later_step_finish(self) -> None:
+        # An error earlier in the list must still mark the agent complete even if
+        # the final step_finish has a non-terminal reason (matches is_log_complete,
+        # which gives any error event priority).
+        events = [
+            _event(100, "error"),
+            _event(200, "step_finish", reason="tool_use"),
+        ]
+        assert self._complete(events) is True
+
+    def test_no_terminal_events_not_complete(self) -> None:
+        assert self._complete([_event(100, "text", text="hi")]) is False


### PR DESCRIPTION
Stacked on `connect-tui-render-faster` (#33), addressing the review feedback. Each item maps to a finding from the review.

## 1. (Medium) Recursive rescan could miss new logs in existing subdirs
`LogWatcher._refresh_log_paths` only re-globbed when the top-level `_opencode_logs` mtime changed, but it globs **recursively** and sub-agent logs live in subdirectories (`app.py` → `_logs_dir/<agent>/<name>.log`). Adding a `.log` inside an already-known subdir bumps *that subdir's* mtime, not the top level's — so a late-spawning nested agent's log could go unpolled for the rest of the session (the exact "pane stays empty" symptom this PR fixes, for nested agents).

Now `_logs_dir_signature()` takes the **max mtime across every directory** in the tree (a cheap directory-only walk, no per-file stat), so a change anywhere triggers a rescan.

## 2. (Low-Med) Redundant drain/re-queue in `_mount_impl`
The code drained the watcher queue with `get_events()`, re-`put` every item back through the private `_watcher._event_queue` just to log a count, then drained again via `_process_pending_events()` (which already calls `get_events()`). Removed the whole dance and the private-field access — `_process_pending_events()` drains and processes directly, and the agent count is still logged on the following line. This also removes a footgun: the re-queue had become load-bearing, so a future "cleanup" of it would silently drop startup events.

## 3. (Low) Completion-check semantic drift
`_is_agent_complete_in_memory` returned on the first terminal event found scanning in reverse, so an `error` event sitting *before* a non-terminal final `step_finish` was missed. Canonical `is_log_complete` gives **any** `error` event priority over the last `step_finish` reason. The check now scans the whole list for an error while still using the last `step_finish` (first seen in reverse) for the reason comparison, matching `is_log_complete`.

## 4. (Nit) Tests
Adds `tests/test_tui_render_followups.py` covering the `AgentState.add_event` timestamp-set dedup, `discover_artifacts` directory pruning (`.venv` and friends), and the in-memory completion semantics — including a regression test for the error-priority case in #3.

## Testing
TUI-adjacent suites pass locally: `test_viewer`, `test_session`, `test_opencode_logparser`, `test_config`, and the new file — 169 passed, 1 skipped. The remaining suite failures in this environment are all "no running Docker daemon" (integration/CLI tests), unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)