### PR TITLE
Add explicit dlab run subcommand (#32)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,17 +36,19 @@ dlab is a Python CLI that runs [opencode](https://opencode.ai) in automated mode
 
 ```bash
 # Basic usage
-dlab --dpack <dpack> --data <data-dir> --env-file .env --work-dir <work-dir> --prompt "Your prompt here"
+dlab run --dpack <dpack> --data <data-dir> --env-file .env --work-dir <work-dir> --prompt "Your prompt here"
 
 # Multiple data files
-dlab --dpack <dpack> --data file1.csv file2.csv --prompt "Compare these"
+dlab run --dpack <dpack> --data file1.csv file2.csv --prompt "Compare these"
 
 # Resume interrupted session
-dlab --dpack <dpack> --continue-dir ./dlab-mmm-workdir-001 --prompt "Continue"
+dlab run --dpack <dpack> --continue-dir ./dlab-mmm-workdir-001 --prompt "Continue"
 
 # Prompt from file
-dlab --dpack <dpack> --data <data-dir> --prompt-file prompt.txt
+dlab run --dpack <dpack> --data <data-dir> --prompt-file prompt.txt
 ```
+
+The `run` subcommand may be omitted as a shorthand (`dlab --dpack ...` works identically).
 
 Required flags:
 - `--dpack` - Path to decision-pack config directory

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pip install dlab-cli
 echo "ANTHROPIC_API_KEY=your-key-here" >> .env
 
 # Run the MMM decision-pack on the included example dataset
-dlab --dpack decision-packs/mmm \
+dlab run --dpack decision-packs/mmm \
   --data decision-packs/mmm/example-data/example_dataset.csv \
   --env-file .env \
   --work-dir ./mmm-run \
@@ -92,7 +92,7 @@ my-dpack/
 See the [poem decision-pack](decision-packs/poem/) for a fully annotated example showing how all the pieces connect. Here's what happens when you run it:
 
 ```bash
-dlab --dpack decision-packs/poem --env-file .env --prompt "Write me a poem about the ocean"
+dlab run --dpack decision-packs/poem --env-file .env --prompt "Write me a poem about the ocean"
 ```
 
 1. dlab builds the Docker image from [`docker/Dockerfile`](decision-packs/poem/docker/Dockerfile) (cached after first run)
@@ -110,7 +110,7 @@ The session directory ends up with parallel instance outputs, logs, and the fina
 ### Run sessions
 
 ```bash
-dlab --dpack PATH --data PATH --prompt TEXT --env-file .env
+dlab run --dpack PATH --data PATH --prompt TEXT --env-file .env
 ```
 
 Builds the Docker image (cached between runs), starts the container, runs pre-run hooks, launches the agent, runs post-run hooks, fixes file ownership, and stops the container. Without `--work-dir`, sessions are auto-numbered by dpack name (`dlab-mmm-workdir-001`, `dlab-mmm-workdir-002`, ...) and can be resumed with `--continue-dir`.
@@ -185,13 +185,13 @@ All environment variables starting with `DLAB_` are automatically forwarded from
 
 ```bash
 # MMM decision-pack: fit models locally instead of on Modal
-DLAB_FIT_MODEL_LOCALLY=1 dlab --dpack mmm --data ./data --prompt "..."
+DLAB_FIT_MODEL_LOCALLY=1 dlab run --dpack mmm --data ./data --prompt "..."
 ```
 
 ## CLI reference
 
 ```bash
-dlab --dpack PATH --data PATH --prompt TEXT   # Run a session
+dlab run --dpack PATH --data PATH --prompt TEXT   # Run a session
 dlab connect WORK_DIR                         # Live TUI monitor
 dlab timeline [WORK_DIR]                      # Execution Gantt chart
 dlab view WORK_DIR                            # Browser-based DAG viewer

--- a/decision-packs/event-forecaster/README.md
+++ b/decision-packs/event-forecaster/README.md
@@ -11,10 +11,10 @@ with credible intervals.
 
 ```bash
 # With local data
-dlab --dpack . --data path/to/data --prompt "When will X happen? Horizons: ..."
+dlab run --dpack . --data path/to/data --prompt "When will X happen? Horizons: ..."
 
 # Without data (domain knowledge only)
-dlab --dpack . --prompt "When will X happen? Horizons: ..."
+dlab run --dpack . --prompt "When will X happen? Horizons: ..."
 ```
 
 ## What it does
@@ -77,4 +77,4 @@ models:
 
 At session setup, dlab injects `models.forecaster` and `models.consolidator` into
 `opencode/parallel_agents/forecaster.yaml`. Override the orchestrator for a single
-run with `dlab --model ...`.
+run with `dlab run --model ...`.

--- a/decision-packs/mmm/README.md
+++ b/decision-packs/mmm/README.md
@@ -146,7 +146,7 @@ Get Modal tokens at https://modal.com/settings/tokens.
 Models are fit on Modal by default. To fit locally instead (slower, no Modal credentials needed), set `DLAB_FIT_MODEL_LOCALLY=1` in your `.env` or pass it as an env var:
 
 ```bash
-DLAB_FIT_MODEL_LOCALLY=1 dlab --dpack decision-packs/mmm --data ./data --prompt "..."
+DLAB_FIT_MODEL_LOCALLY=1 dlab run --dpack decision-packs/mmm --data ./data --prompt "..."
 ```
 
 Local fitting runs at 1-2 it/s (PyTensor) or 3-8 it/s (numpyro). Modal runs at 5-10 it/s.

--- a/decision-packs/modal-example/README.md
+++ b/decision-packs/modal-example/README.md
@@ -24,7 +24,7 @@ Get Modal tokens at https://modal.com/settings/tokens.
 ## Run
 
 ```bash
-dlab --dpack decision-packs/modal-example --env-file .env --prompt "Run a test computation on Modal"
+dlab run --dpack decision-packs/modal-example --env-file .env --prompt "Run a test computation on Modal"
 ```
 
 ## Environment variables

--- a/dlab/cli.py
+++ b/dlab/cli.py
@@ -40,10 +40,16 @@ from dlab.timeline import run_timeline
 
 app = typer.Typer(
     name="dlab",
-    help="Run opencode in automated mode, sandboxed with Docker",
+    help=(
+        "Run opencode in automated mode, sandboxed with Docker.\n\n"
+        "The primary command is [bold]dlab run[/bold]; its options may also "
+        "be passed directly at the root as a shorthand "
+        "(dlab --dpack ... = dlab run --dpack ...)."
+    ),
     no_args_is_help=False,
     add_completion=True,
     suggest_commands=True,
+    rich_markup_mode="rich",
 )
 
 
@@ -140,7 +146,7 @@ CONFIG_DIR = "{config_dir}"
 
 
 def main() -> None:
-    cmd = ["dlab", "--dpack", CONFIG_DIR] + sys.argv[1:]
+    cmd = ["dlab", "run", "--dpack", CONFIG_DIR] + sys.argv[1:]
     result = subprocess.run(cmd)
     sys.exit(result.returncode)
 
@@ -153,6 +159,84 @@ if __name__ == "__main__":
 @app.callback(invoke_without_command=True)
 def _main(
     ctx: typer.Context,
+    # Run-mode options are accepted at the root as a backward-compatible
+    # shorthand for `dlab run` but hidden from the root help so that
+    # `dlab --help` cleanly lists the commands (see issue #32). The
+    # documented definitions live on the `run` command below.
+    dpack: Annotated[
+        str | None,
+        typer.Option("--dpack", metavar="PATH", hidden=True),
+    ] = None,
+    data: Annotated[
+        list[str] | None,
+        typer.Option("--data", metavar="PATH", hidden=True),
+    ] = None,
+    model: Annotated[
+        str | None,
+        typer.Option("--model", metavar="MODEL", hidden=True),
+    ] = None,
+    prompt: Annotated[
+        str | None,
+        typer.Option("--prompt", metavar="TEXT", hidden=True),
+    ] = None,
+    prompt_file: Annotated[
+        str | None,
+        typer.Option("--prompt-file", metavar="PATH", hidden=True),
+    ] = None,
+    work_dir: Annotated[
+        str | None,
+        typer.Option("--work-dir", metavar="PATH", hidden=True),
+    ] = None,
+    continue_dir: Annotated[
+        str | None,
+        typer.Option("--continue-dir", metavar="PATH", hidden=True),
+    ] = None,
+    rebuild: Annotated[
+        bool,
+        typer.Option("--rebuild", hidden=True),
+    ] = False,
+    env_file: Annotated[
+        str | None,
+        typer.Option("--env-file", metavar="PATH", hidden=True),
+    ] = None,
+    no_sandboxing: Annotated[
+        bool,
+        typer.Option("--no-sandboxing", hidden=True),
+    ] = False,
+) -> None:
+    """Run opencode in automated mode, sandboxed with Docker.
+
+    The primary command is `dlab run` (see `dlab run --help`). Its options
+    may also be passed directly at the root as a shorthand:
+    `dlab --dpack ... --prompt ...` is equivalent to `dlab run --dpack ...`.
+    """
+    if ctx.resilient_parsing:
+        return
+
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if any([dpack, data, prompt, prompt_file, continue_dir]):
+        exit_code = cmd_run(
+            dpack=dpack,
+            data=data,
+            model=model,
+            prompt=prompt,
+            prompt_file=prompt_file,
+            work_dir=work_dir,
+            continue_dir=continue_dir,
+            rebuild=rebuild,
+            env_file=env_file,
+            no_sandboxing=no_sandboxing,
+        )
+        raise typer.Exit(code=exit_code)
+
+    typer.echo(ctx.get_help())
+    raise typer.Exit(code=0)
+
+
+@app.command("run")
+def _cmd_run_command(
     dpack: Annotated[
         str | None,
         typer.Option(
@@ -218,30 +302,20 @@ def _main(
         ),
     ] = False,
 ) -> None:
-    """Run opencode in automated mode, sandboxed with Docker."""
-    if ctx.resilient_parsing:
-        return
-
-    if ctx.invoked_subcommand is not None:
-        return
-
-    if any([dpack, data, prompt, prompt_file, continue_dir]):
-        exit_code = cmd_run(
-            dpack=dpack,
-            data=data,
-            model=model,
-            prompt=prompt,
-            prompt_file=prompt_file,
-            work_dir=work_dir,
-            continue_dir=continue_dir,
-            rebuild=rebuild,
-            env_file=env_file,
-            no_sandboxing=no_sandboxing,
-        )
-        raise typer.Exit(code=exit_code)
-
-    typer.echo(ctx.get_help())
-    raise typer.Exit(code=0)
+    """Run opencode in automated mode, sandboxed with Docker (default command)."""
+    exit_code = cmd_run(
+        dpack=dpack,
+        data=data,
+        model=model,
+        prompt=prompt,
+        prompt_file=prompt_file,
+        work_dir=work_dir,
+        continue_dir=continue_dir,
+        rebuild=rebuild,
+        env_file=env_file,
+        no_sandboxing=no_sandboxing,
+    )
+    raise typer.Exit(code=exit_code)
 
 
 def cmd_run(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,14 +8,14 @@ Complete reference for all dlab commands and options.
 dlab [command] [options]
 ```
 
-If no command is specified and run-mode arguments are provided, dlab runs in **run mode**.
+The primary command is `dlab run`. As a backward-compatible shorthand, its options may also be passed directly at the root — `dlab --dpack ...` is equivalent to `dlab run --dpack ...`.
 
-## Run Mode
+## run
 
 Execute opencode in a Docker container with your data and prompt.
 
 ```bash
-dlab --dpack PATH --data PATH [--data PATH ...] --prompt TEXT [options]
+dlab run --dpack PATH --data PATH [--data PATH ...] --prompt TEXT [options]
 ```
 
 ### Required Arguments
@@ -52,7 +52,7 @@ All environment variables starting with `DLAB_` are automatically forwarded from
 
 ```bash
 # Example: MMM decision-pack uses this to control local vs Modal fitting
-DLAB_FIT_MODEL_LOCALLY=1 dlab --dpack mmm --data ./data --prompt "..."
+DLAB_FIT_MODEL_LOCALLY=1 dlab run --dpack mmm --data ./data --prompt "..."
 ```
 
 ### Continue Mode
@@ -60,7 +60,7 @@ DLAB_FIT_MODEL_LOCALLY=1 dlab --dpack mmm --data ./data --prompt "..."
 Resume an interrupted session:
 
 ```bash
-dlab --dpack ./my-dpack --continue-dir ./analysis-001 --prompt "Continue"
+dlab run --dpack ./my-dpack --continue-dir ./analysis-001 --prompt "Continue"
 ```
 
 This refreshes the `.opencode` config and hook scripts from the decision-pack, then runs opencode in the existing work directory. Cannot be combined with `--data`.
@@ -69,22 +69,22 @@ This refreshes the `.opencode` config and hook scripts from the decision-pack, t
 
 ```bash
 # Basic usage
-dlab --dpack ./my-dpack --data ./data --prompt "Analyze this CSV"
+dlab run --dpack ./my-dpack --data ./data --prompt "Analyze this CSV"
 
 # Multiple data files (repeat --data for each file)
-dlab --dpack ./my-dpack --data file1.csv --data file2.csv --prompt "Compare"
+dlab run --dpack ./my-dpack --data file1.csv --data file2.csv --prompt "Compare"
 
 # With model override
-dlab --dpack ./my-dpack --data ./data \
+dlab run --dpack ./my-dpack --data ./data \
          --prompt "Build a model" \
          --model anthropic/claude-opus-4
 
 # Resume interrupted session
-dlab --dpack ./my-dpack --continue-dir ./analysis-001 \
+dlab run --dpack ./my-dpack --continue-dir ./analysis-001 \
          --prompt "Continue the analysis"
 
 # Environment file (auto-detected from decision-pack .env if present)
-dlab --dpack ./my-dpack --data ./data --prompt "Analyze"
+dlab run --dpack ./my-dpack --data ./data --prompt "Analyze"
 ```
 
 ### CLI Output

--- a/docs/decision-packs.md
+++ b/docs/decision-packs.md
@@ -83,7 +83,7 @@ hooks:
 
 ### Model Roles
 
-`default_model` is the orchestrator model (overridable at run time with `dlab --model`). The optional `models:` block overrides models for the other roles: at session setup, `forecaster` is injected as `default_model` and `consolidator` as `summarizer_model` into each YAML file under `opencode/parallel_agents/`. Omitted roles fall back to `default_model`.
+`default_model` is the orchestrator model (overridable at run time with `dlab run --model`). The optional `models:` block overrides models for the other roles: at session setup, `forecaster` is injected as `default_model` and `consolidator` as `summarizer_model` into each YAML file under `opencode/parallel_agents/`. Omitted roles fall back to `default_model`.
 
 ## opencode/opencode.json
 
@@ -249,7 +249,7 @@ For example, the MMM decision-pack uses `DLAB_FIT_MODEL_LOCALLY=1` to switch bet
 To use from the command line:
 
 ```bash
-DLAB_FIT_MODEL_LOCALLY=1 dlab --dpack mmm --data ./data --prompt "..."
+DLAB_FIT_MODEL_LOCALLY=1 dlab run --dpack mmm --data ./data --prompt "..."
 ```
 
 Or add to your `.env` file:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -57,12 +57,12 @@ Images are cached based on a hash of the `docker/` directory contents and the `o
 
 ```bash
 # First run: builds the image
-dlab --dpack ./my-dpack --data ./data --prompt "Test"
+dlab run --dpack ./my-dpack --data ./data --prompt "Test"
 # [1/4] Setting up environment
 #       Building image: my-dpack-img
 
 # Second run: uses cached image
-dlab --dpack ./my-dpack --data ./data --prompt "Test"
+dlab run --dpack ./my-dpack --data ./data --prompt "Test"
 # [1/4] Setting up environment
 #       Image: my-dpack-img (cached)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ dlab solves the problem of running AI coding agents in a controlled, reproducibl
 dlab create-dpack
 
 # Run with a decision-pack
-dlab --dpack ./my-dpack \
+dlab run --dpack ./my-dpack \
          --data ./my-data \
          --prompt "Analyze this data"
 
@@ -74,7 +74,7 @@ dlab connect ./analysis-001
 dlab timeline ./analysis-001
 
 # Resume an interrupted session
-dlab --dpack ./my-dpack \
+dlab run --dpack ./my-dpack \
          --continue-dir ./analysis-001 \
          --prompt "Continue the analysis"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ API keys are passed to the Docker container via `--env-file`. The create-dpack w
 cp my-dpack/.env.example my-dpack/.env
 
 # The CLI auto-detects .env in the decision-pack directory
-dlab --dpack ./my-dpack --data ./data --prompt "Analyze"
+dlab run --dpack ./my-dpack --data ./data --prompt "Analyze"
 ```
 
 ## Platform Support

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -26,7 +26,7 @@ By default, sessions are created in the **current working directory**:
 
 You can specify a custom location with `--work-dir`:
 ```bash
-dlab --dpack ./my-dpack --data ./data \
+dlab run --dpack ./my-dpack --data ./data \
          --prompt "Test" --work-dir ./my-custom-session
 ```
 
@@ -103,7 +103,7 @@ Each session stores metadata:
 Data is **copied** to the session, not symlinked:
 
 ```bash
-dlab --dpack ./my-dpack --data ./my-data-dir --prompt "Analyze"
+dlab run --dpack ./my-dpack --data ./my-data-dir --prompt "Analyze"
 ```
 
 This copies the entire directory to `{session}/data/`.
@@ -113,7 +113,7 @@ This copies the entire directory to `{session}/data/`.
 You can pass multiple files instead of a directory:
 
 ```bash
-dlab --dpack ./my-dpack --data file1.csv file2.csv config.json --prompt "Compare"
+dlab run --dpack ./my-dpack --data file1.csv file2.csv config.json --prompt "Compare"
 ```
 
 Each file is copied into `{session}/data/`.
@@ -121,7 +121,7 @@ Each file is copied into `{session}/data/`.
 ### Mixed Files and Directories
 
 ```bash
-dlab --dpack ./my-dpack --data ./images/ report.csv --prompt "Process"
+dlab run --dpack ./my-dpack --data ./images/ report.csv --prompt "Process"
 ```
 
 Directories are copied as subdirectories, files are copied directly into `data/`.
@@ -131,7 +131,7 @@ Directories are copied as subdirectories, files are copied directly into `data/`
 If the decision-pack sets `requires_data: false`, `--data` is optional:
 
 ```bash
-dlab --dpack ./prompt-only-dpack --prompt "Write a poem"
+dlab run --dpack ./prompt-only-dpack --prompt "Write a poem"
 ```
 
 ## Continue Mode
@@ -139,7 +139,7 @@ dlab --dpack ./prompt-only-dpack --prompt "Write a poem"
 Resume an interrupted session:
 
 ```bash
-dlab --dpack ./my-dpack --continue-dir ./analysis-001 --prompt "Continue"
+dlab run --dpack ./my-dpack --continue-dir ./analysis-001 --prompt "Continue"
 ```
 
 This:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,8 +26,20 @@ class TestTyperApp:
         assert result.exit_code == 0
         assert "dlab" in result.output
 
-    def test_run_mode_options_appear_in_help(self) -> None:
+    def test_root_help_lists_run_command_not_run_options(self) -> None:
+        """Root help shows the run command; run-mode options are hidden
+        there so commands and options aren't interleaved (issue #32).
+        (--dpack does appear once, in the description's shorthand example,
+        so assert on options that no prose mentions.)"""
         result = runner.invoke(app, ["--help"])
+        assert "run" in result.output
+        assert "--no-sandboxing" not in result.output
+        assert "--prompt-file" not in result.output
+        assert "--continue-dir" not in result.output
+
+    def test_run_help_shows_run_options(self) -> None:
+        result = runner.invoke(app, ["run", "--help"])
+        assert result.exit_code == 0
         assert "--dpack" in result.output
         assert "--data" in result.output
         assert "--prompt" in result.output
@@ -58,6 +70,16 @@ class TestTyperApp:
         result = runner.invoke(app, [])
         assert result.exit_code == 0
         assert "dlab" in result.output
+
+    def test_run_subcommand_and_shorthand_are_equivalent(self) -> None:
+        """`dlab run --dpack ...` and the root shorthand must take the same
+        code path (issue #32): both hit cmd_run and fail identically on an
+        invalid dpack (exit 1, not a parse error)."""
+        args: list[str] = ["--dpack", "/nonexistent", "--prompt", "test"]
+        explicit = runner.invoke(app, ["run", *args])
+        shorthand = runner.invoke(app, args)
+        assert explicit.exit_code == 1
+        assert shorthand.exit_code == 1
 
     def test_data_repeated_flag(self) -> None:
         # exit 1 (invalid dpack) is fine; exit 2 means a parse error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,97 @@ class TestTyperApp:
         assert result.exit_code != 2
 
 
+class TestRunSubcommand:
+    """Behavioral tests for the explicit `dlab run` subcommand (issue #32).
+
+    Every test that exercises an error path doubles as a wiring check: an
+    exit code of 1 (not 2) proves the invocation parsed and reached
+    cmd_run's own validation rather than dying in click.
+    """
+
+    ALL_RUN_OPTIONS: tuple[str, ...] = (
+        "--dpack", "--data", "--model", "--prompt", "--prompt-file",
+        "--work-dir", "--continue-dir", "--rebuild", "--env-file",
+        "--no-sandboxing",
+    )
+
+    def test_run_help_lists_every_run_option(self) -> None:
+        result = runner.invoke(app, ["run", "--help"])
+        assert result.exit_code == 0
+        for opt in self.ALL_RUN_OPTIONS:
+            assert opt in result.output, f"{opt} missing from `dlab run --help`"
+
+    def test_run_without_args_fails_like_run_mode(self) -> None:
+        """`dlab run` with no options reaches cmd_run and fails on the
+        missing --dpack (exit 1), it does not print help or parse-error."""
+        result = runner.invoke(app, ["run"])
+        assert result.exit_code == 1
+
+    def test_run_rejects_positional_arguments(self) -> None:
+        """`run` takes options only; a stray positional is a parse error."""
+        result = runner.invoke(app, ["run", "some-dpack"])
+        assert result.exit_code == 2
+
+    def test_run_repeated_data_flag_parses(self) -> None:
+        result = runner.invoke(
+            app,
+            ["run", "--dpack", "/nonexistent", "--data", "/a", "--data", "/b",
+             "--prompt", "test"],
+        )
+        # exit 1 (invalid dpack) is fine; exit 2 would mean a parse error
+        assert result.exit_code == 1
+
+    def test_run_missing_data_fails(self, dpack_config_dir: Path) -> None:
+        result = runner.invoke(
+            app, ["run", "--dpack", str(dpack_config_dir), "--prompt", "test"]
+        )
+        assert result.exit_code == 1
+
+    def test_run_both_prompt_args_fails(
+        self, dpack_config_dir: Path, data_dir: Path, tmp_path: Path
+    ) -> None:
+        prompt_file: Path = tmp_path / "prompt.md"
+        prompt_file.write_text("file prompt")
+        result = runner.invoke(
+            app,
+            ["run", "--dpack", str(dpack_config_dir), "--data", str(data_dir),
+             "--prompt", "inline", "--prompt-file", str(prompt_file)],
+        )
+        assert result.exit_code == 1
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["--prompt", "test"],                                # missing dpack
+            ["--dpack", "/nonexistent", "--prompt", "test"],     # invalid dpack
+            ["--dpack", "/nonexistent", "--data", "/a", "--data", "/b",
+             "--prompt", "t"],                                   # repeated data
+        ],
+        ids=["missing-dpack", "invalid-dpack", "repeated-data"],
+    )
+    def test_shorthand_and_subcommand_agree(self, args: list[str]) -> None:
+        """The root shorthand and `run` must exit identically for the same
+        argument vector — they share cmd_run."""
+        explicit = runner.invoke(app, ["run", *args])
+        shorthand = runner.invoke(app, args)
+        assert explicit.exit_code == shorthand.exit_code == 1
+
+    def test_shorthand_prompt_value_run_is_not_a_subcommand(self) -> None:
+        """A --prompt value of "run" must stay an option value, not get
+        dispatched as the run subcommand."""
+        result = runner.invoke(
+            app, ["--dpack", "/nonexistent", "--prompt", "run"]
+        )
+        # invalid dpack error from cmd_run, not a parse/dispatch error
+        assert result.exit_code == 1
+
+    def test_run_unknown_flag_is_parse_error(self) -> None:
+        result = runner.invoke(
+            app, ["run", "--dpack", "/x", "--bogus-flag"]
+        )
+        assert result.exit_code == 2
+
+
 class TestCmdRun:
     """Tests for cmd_run function."""
 
@@ -618,6 +709,15 @@ class TestCmdInstall:
         assert "dlab" in content
         assert "--dpack" in content
         assert str(dpack_config_dir.resolve()) in content
+
+    def test_wrapper_uses_explicit_run_subcommand(
+        self, dpack_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Generated wrappers call `dlab run --dpack ...` explicitly (#32)."""
+        bin_dir: Path = tmp_path / "bin"
+        assert cmd_install(dpack_path=str(dpack_config_dir), bin_dir=str(bin_dir)) == 0
+        content: str = (bin_dir / "test-dpack").read_text()
+        assert '"dlab", "run", "--dpack"' in content
 
     def test_creates_bin_dir_if_missing(
         self, dpack_config_dir: Path, tmp_path: Path


### PR DESCRIPTION
## Summary

Implements #32 (@daniel-s-tccc's UX proposal): an explicit `dlab run` subcommand, with the current root-level option form kept as a fully backward-compatible shorthand.

**What changes for users:**
- `dlab run --dpack ... --prompt ...` now works and is the documented form
- `dlab --help` cleanly separates commands from options — `run` is listed first and the description explains the shorthand; run-mode options are hidden at the root (still accepted)
- `dlab run --help` shows exactly the run options
- `dlab install` wrapper scripts generate explicit `dlab run` calls; previously installed wrappers keep working via the shorthand
- All docs and pack READMEs prefer `dlab run`, with the shorthand noted in cli-reference and CLAUDE.md

**What doesn't change:** every existing invocation (`dlab --dpack ...`) parses and behaves identically — the shorthand and the subcommand call the same `cmd_run`.

## Test plan

- New tests: root help hides run options / lists `run`; `run --help` shows the options; explicit and shorthand invocations take the same code path (identical exit behavior)
- `pytest tests/test_cli.py tests/test_session.py tests/test_skill_sync.py tests/test_parallel_tool.py` — all passing

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)