### PR TITLE
Fix #57: open artifacts without a shell (also resolves #62)

### DIFF
--- a/dlab/tui/widgets/artifacts_pane.py
+++ b/dlab/tui/widgets/artifacts_pane.py
@@ -10,6 +10,8 @@ import csv
 import io
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 from rich.console import Group
@@ -43,6 +45,41 @@ EXCLUDE_DIRS = {
     ".tox",
     ".mypy_cache",
 }
+
+
+def open_file_externally(path: Path | None) -> bool:
+    """
+    Open a file with the system's default application, without a shell.
+
+    Artifact filenames are agent-controlled, so they must never pass
+    through a shell: on Windows this uses ``os.startfile`` (no cmd.exe),
+    on macOS/Linux the platform opener binary with an argument list.
+
+    Parameters
+    ----------
+    path : Path | None
+        File to open.
+
+    Returns
+    -------
+    bool
+        True if an opener was launched, False if the path is missing/does
+        not exist or no opener is available on this system.
+    """
+    if not path or not path.exists():
+        return False
+    try:
+        if sys.platform == "win32":
+            os.startfile(str(path))
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", str(path)])
+        else:
+            subprocess.Popen(["xdg-open", str(path)])
+    except OSError:
+        # Opener binary missing (e.g. no xdg-open) or file vanished —
+        # report failure instead of crashing the TUI.
+        return False
+    return True
 
 # Image extensions
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp"}
@@ -325,21 +362,7 @@ class ArtifactList(ListView):
         bool
             True if file was opened, False if no file highlighted.
         """
-        import subprocess
-        import sys
-
-        path = self.get_highlighted_path()
-        if not path or not path.exists():
-            return False
-
-        if sys.platform == "darwin":
-            subprocess.Popen(["open", str(path)])
-        elif sys.platform == "win32":
-            subprocess.Popen(["start", str(path)], shell=True)
-        else:
-            subprocess.Popen(["xdg-open", str(path)])
-
-        return True
+        return open_file_externally(self.get_highlighted_path())
 
 
 class FileViewer(VerticalScroll, can_focus=True):
@@ -452,21 +475,7 @@ class FileViewer(VerticalScroll, can_focus=True):
         bool
             True if file was opened, False if no file selected.
         """
-        import subprocess
-        import sys
-
-        if not self._file_path or not self._file_path.exists():
-            return False
-
-        # Open with system default viewer
-        if sys.platform == "darwin":
-            subprocess.Popen(["open", str(self._file_path)])
-        elif sys.platform == "win32":
-            subprocess.Popen(["start", str(self._file_path)], shell=True)
-        else:
-            subprocess.Popen(["xdg-open", str(self._file_path)])
-
-        return True
+        return open_file_externally(self._file_path)
 
 
 class ImageDisplay(Static):
@@ -522,18 +531,7 @@ class ImageDisplay(Static):
 
     def _open_file(self) -> None:
         """Open the file in system default viewer."""
-        import subprocess
-        import sys
-
-        if not self._path.exists():
-            return
-
-        if sys.platform == "darwin":
-            subprocess.Popen(["open", str(self._path)])
-        elif sys.platform == "win32":
-            subprocess.Popen(["start", str(self._path)], shell=True)
-        else:
-            subprocess.Popen(["xdg-open", str(self._path)])
+        open_file_externally(self._path)
 
 
 class PdfDisplay(Static):
@@ -570,18 +568,7 @@ class PdfDisplay(Static):
 
     def _open_file(self) -> None:
         """Open the file in system default viewer."""
-        import subprocess
-        import sys
-
-        if not self._path.exists():
-            return
-
-        if sys.platform == "darwin":
-            subprocess.Popen(["open", str(self._path)])
-        elif sys.platform == "win32":
-            subprocess.Popen(["start", str(self._path)], shell=True)
-        else:
-            subprocess.Popen(["xdg-open", str(self._path)])
+        open_file_externally(self._path)
 
 
 class MarkdownDisplay(Static):

--- a/tests/test_artifact_open.py
+++ b/tests/test_artifact_open.py
@@ -1,0 +1,52 @@
+"""
+Tests for opening artifacts externally (issues #57, #62).
+
+Artifact filenames are agent-controlled; opening them must never route
+through a shell. These tests guard the fix without actually launching
+system viewers.
+"""
+
+from pathlib import Path
+
+from dlab.tui.widgets.artifacts_pane import open_file_externally
+
+TUI_DIR = Path(__file__).parent.parent / "dlab" / "tui"
+
+
+class TestOpenFileExternally:
+    def test_none_path_returns_false(self) -> None:
+        assert open_file_externally(None) is False
+
+    def test_missing_path_returns_false(self, tmp_path: Path) -> None:
+        assert open_file_externally(tmp_path / "does-not-exist.md") is False
+
+    def test_missing_path_with_shell_metacharacters_returns_false(
+        self, tmp_path: Path
+    ) -> None:
+        # A hostile artifact name must be treated as a plain path — here it
+        # doesn't exist, so no opener may be spawned at all.
+        hostile = tmp_path / "report & echo pwned.md"
+        assert open_file_externally(hostile) is False
+
+
+class TestNoShellInTui:
+    def test_no_shell_true_anywhere_in_tui(self) -> None:
+        """Regression guard for #57: no subprocess call in the TUI may use
+        shell=True — artifact names are agent-controlled input."""
+        offenders: list[str] = []
+        for py in TUI_DIR.rglob("*.py"):
+            if "shell=True" in py.read_text():
+                offenders.append(str(py))
+        assert not offenders, f"shell=True found in: {offenders}"
+
+    def test_windows_path_uses_startfile(self) -> None:
+        """Windows must use os.startfile (no cmd.exe), not `start`."""
+        source: str = (TUI_DIR / "widgets" / "artifacts_pane.py").read_text()
+        assert "os.startfile" in source
+        assert '"start"' not in source
+
+    def test_single_open_helper_is_used(self) -> None:
+        """Regression guard for #62: exactly one place spawns openers."""
+        source: str = (TUI_DIR / "widgets" / "artifacts_pane.py").read_text()
+        assert source.count('subprocess.Popen(["open"') == 1
+        assert source.count('subprocess.Popen(["xdg-open"') == 1

--- a/tests/test_artifact_open.py
+++ b/tests/test_artifact_open.py
@@ -2,15 +2,41 @@
 Tests for opening artifacts externally (issues #57, #62).
 
 Artifact filenames are agent-controlled; opening them must never route
-through a shell. These tests guard the fix without actually launching
-system viewers.
+through a shell. The behavioral tests below spawn a REAL fake opener (a
+recording shim placed on PATH) rather than mocking subprocess, per the
+project's no-mocks policy — so they exercise the actual spawn path and
+prove the filename arrives as one intact argument with no shell parsing.
 """
+
+import os
+import sys
+
+import pytest
 
 from pathlib import Path
 
 from dlab.tui.widgets.artifacts_pane import open_file_externally
 
 TUI_DIR = Path(__file__).parent.parent / "dlab" / "tui"
+
+
+@pytest.fixture
+def fake_opener(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Put a recording `xdg-open` (and `open`) shim first on PATH.
+
+    monkeypatch here only edits the PATH env var and argv-recording target
+    — no library call is patched; the helper really execs the shim.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    record = tmp_path / "argv.txt"
+    shim = "#!/bin/sh\n" f'printf "%s\\n" "$@" > "{record}"\n'
+    for name in ("xdg-open", "open"):
+        p = bindir / name
+        p.write_text(shim)
+        p.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+    return record
 
 
 class TestOpenFileExternally:
@@ -27,6 +53,48 @@ class TestOpenFileExternally:
         # doesn't exist, so no opener may be spawned at all.
         hostile = tmp_path / "report & echo pwned.md"
         assert open_file_externally(hostile) is False
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX opener shim; Windows uses os.startfile (no argv to record)",
+)
+class TestSpawnPassesFilenameSafely:
+    """Behavioral tests: the real spawn path receives the filename as one
+    intact argument, with shell metacharacters inert (issue #57)."""
+
+    def test_plain_file_passed_as_single_arg(
+        self, tmp_path: Path, fake_opener: Path
+    ) -> None:
+        f = tmp_path / "report.md"
+        f.write_text("x")
+        assert open_file_externally(f) is True
+        # Wait for the detached shim to write its record.
+        import time
+        for _ in range(50):
+            if fake_opener.exists():
+                break
+            time.sleep(0.02)
+        recorded = fake_opener.read_text().splitlines()
+        assert recorded == [str(f)]
+
+    def test_hostile_filename_is_inert_single_arg(
+        self, tmp_path: Path, fake_opener: Path
+    ) -> None:
+        # The classic injection payload as a real, existing filename.
+        f = tmp_path / "report & touch PWNED.md"
+        f.write_text("x")
+        assert open_file_externally(f) is True
+        import time
+        for _ in range(50):
+            if fake_opener.exists():
+                break
+            time.sleep(0.02)
+        recorded = fake_opener.read_text().splitlines()
+        # Exactly one argument — the whole name — not split on the shell '&'.
+        assert recorded == [str(f)]
+        # And the injected side effect never happened.
+        assert not (tmp_path / "PWNED").exists()
 
 
 class TestNoShellInTui:


### PR DESCRIPTION
## Problem

`[audit]` issue #57: the TUI's "open artifact externally" path on Windows was `subprocess.Popen(["start", str(path)], shell=True)`. With `shell=True`, the agent-controlled artifact filename becomes part of a `cmd.exe` command line — a file named `report & calc.exe.md` created by an agent inside the sandbox would execute the injected command **on the host** the moment a user opens it from `dlab connect`. The same block was copy-pasted in four widgets (the duplication flagged in #62), and a missing opener binary (`xdg-open` on minimal systems) raised instead of failing gracefully.

## Fix

- Single module-level `open_file_externally(path) -> bool`: `os.startfile` on Windows (opens via the OS association API, no shell at all), argument-list `open`/`xdg-open` on macOS/Linux (already shell-free), `OSError` caught → `False` instead of a TUI crash, missing/None paths → `False`.
- All four call sites (`ArtifactList.open_highlighted`, `FileViewer`, `ImageDisplay`, `PdfDisplay`) delegate to it — **closes #62** as a side effect.
- `subprocess`/`sys` imports moved to module top per repo style.

## Tests

`tests/test_artifact_open.py`: hostile/missing paths return False without spawning; regression guards — no `shell=True` anywhere under `dlab/tui/`, Windows path uses `os.startfile`, exactly one opener call site. 15 passed (new + TUI follow-up suite).

Closes #57. Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)