### PR TITLE
Fix #56: curate the environment passed to parallel subagents

### DIFF
--- a/dlab/js/parallel-agents.ts
+++ b/dlab/js/parallel-agents.ts
@@ -4,6 +4,42 @@ import { readFileSync, mkdirSync, writeFileSync, existsSync, appendFileSync, rea
 const yaml = require("yaml")
 import { join, basename } from "path"
 
+// Conservative built-in fallback used only if the dlab-written allowlist is
+// absent (e.g. a workdir created before this change and resumed). dlab writes
+// the authoritative list — the union of operational vars and every known LLM
+// provider credential — to .opencode/instance-env-allowlist.json at setup.
+const FALLBACK_ENV_EXACT = new Set([
+  "PATH", "HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "LC_CTYPE",
+  "TERM", "TMPDIR", "TMP", "TEMP", "PWD", "SHELL",
+  "PYTHONPATH", "PYTHONUNBUFFERED", "NODE_PATH",
+  "SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE",
+])
+const FALLBACK_ENV_PREFIXES = ["DLAB_", "OPENCODE_", "AWS_", "AZURE_", "GOOGLE_", "VERTEX_", "CLOUDFLARE_", "GITHUB_"]
+
+// Build a curated environment for a spawned instance/consolidator. Passing the
+// full parent environment leaks unrelated host state (shell history paths,
+// ambient secrets) into the subagent, readable via bash — a real leak in
+// --no-sandboxing local mode where the parent env is the user's shell (#56).
+function buildInstanceEnv(cwd: string): Record<string, string> {
+  let exact = FALLBACK_ENV_EXACT
+  let prefixes = FALLBACK_ENV_PREFIXES
+  try {
+    const allow = JSON.parse(readFileSync(join(cwd, ".opencode", "instance-env-allowlist.json"), "utf-8"))
+    if (Array.isArray(allow.exact)) exact = new Set(allow.exact)
+    if (Array.isArray(allow.prefixes)) prefixes = allow.prefixes
+  } catch {
+    // Allowlist missing/unreadable — fall back to the built-in conservative set.
+  }
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v === undefined) continue
+    if (exact.has(k) || prefixes.some((p: string) => k.startsWith(p))) {
+      out[k] = v
+    }
+  }
+  return out
+}
+
 // Helper: Copy directory contents excluding certain paths
 function copyWorkDir(src: string, dest: string, exclude: string[]) {
   mkdirSync(dest, { recursive: true })
@@ -301,7 +337,7 @@ CRITICAL OUTPUT RULES:
         cwd: instanceDir,
         stdout: "pipe",
         stderr: "pipe",
-        env: process.env,  // Inherit PYTHONPATH and other env vars
+        env: buildInstanceEnv(cwd),  // Curated env (allowlist); never the full host env (#56)
       })
 
       // Stream to logs (async)
@@ -388,7 +424,7 @@ RULES:
         cwd: runDir,
         stdout: "pipe",
         stderr: "pipe",
-        env: process.env,  // Inherit PYTHONPATH and other env vars
+        env: buildInstanceEnv(cwd),  // Curated env (allowlist); never the full host env (#56)
       })
 
       // Stream stdout to log file (don't use as summary - it's JSON logs)

--- a/dlab/session.py
+++ b/dlab/session.py
@@ -10,11 +10,60 @@ from pathlib import Path
 from typing import Any
 
 from dlab.config import apply_model_roles_to_opencode, resolve_model_roles
+from dlab.create_dpack import KNOWN_PROVIDER_ENVS
 from dlab.model_fallback import process_opencode_dir
 from dlab.parallel_tool import PARALLEL_AGENTS_SOURCE
 
 
 STATE_FILE: str = ".state.json"
+
+# Environment variables a spawned instance/consolidator needs, beyond the LLM
+# provider credentials (which are added from KNOWN_PROVIDER_ENVS). Passing the
+# full parent environment to subagents leaks unrelated host state — shell
+# history paths, ambient secrets — which the subagent can read via bash,
+# especially in --no-sandboxing local mode where the parent env is the user's
+# shell (issue #56). This is the authoritative allowlist; parallel-agents.ts
+# reads it and filters process.env accordingly.
+INSTANCE_ENV_EXACT: list[str] = [
+    "PATH", "HOME", "USER", "LOGNAME", "LANG", "LC_ALL", "LC_CTYPE",
+    "TERM", "TMPDIR", "TMP", "TEMP", "PWD", "SHELL",
+    "PYTHONPATH", "PYTHONUNBUFFERED", "NODE_PATH",
+    "SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE",
+]
+# Prefixes whose variables are always forwarded: dlab config (dpacks rely on
+# DLAB_* forwarding), opencode's own config, and cloud-provider credential
+# families whose names do not end in _API_KEY (AWS/Azure/Vertex/etc.).
+INSTANCE_ENV_PREFIXES: list[str] = [
+    "DLAB_", "OPENCODE_", "AWS_", "AZURE_", "GOOGLE_", "VERTEX_",
+    "CLOUDFLARE_", "GITHUB_",
+]
+
+
+def write_instance_env_allowlist(opencode_dest: Path) -> None:
+    """
+    Write the environment allowlist that parallel-agents.ts uses to filter
+    the subagent environment (issue #56).
+
+    The exact-name list is the union of operational variables and every LLM
+    provider credential variable known to dlab (bundled from models.dev), so
+    exotic providers keep working without hardcoding names in the TypeScript
+    tool. Prefix rules cover dlab/opencode config and cloud-provider families.
+
+    Parameters
+    ----------
+    opencode_dest : Path
+        The work directory's ``.opencode`` directory.
+    """
+    provider_vars: set[str] = {
+        var for keys in KNOWN_PROVIDER_ENVS.values() for var in keys
+    }
+    allowlist: dict[str, list[str]] = {
+        "exact": sorted(set(INSTANCE_ENV_EXACT) | provider_vars),
+        "prefixes": INSTANCE_ENV_PREFIXES,
+    }
+    (opencode_dest / "instance-env-allowlist.json").write_text(
+        json.dumps(allowlist, indent=2)
+    )
 
 
 def _session_dir_prefix(dpack_name: str) -> str:
@@ -225,6 +274,7 @@ def setup_opencode_config(
         tools_dir: Path = opencode_dest / "tools"
         tools_dir.mkdir(exist_ok=True)
         (tools_dir / "parallel-agents.ts").write_text(PARALLEL_AGENTS_SOURCE)
+        write_instance_env_allowlist(opencode_dest)
 
         # Ensure yaml dependency exists in package.json (needed by parallel-agents.ts)
         package_json_path: Path = opencode_dest / "package.json"

--- a/tests/test_instance_env.py
+++ b/tests/test_instance_env.py
@@ -1,0 +1,156 @@
+"""
+Tests for the parallel-instance environment allowlist (issue #56).
+
+Subagents must receive a curated environment, not the full host env.
+dlab writes the authoritative allowlist; parallel-agents.ts filters
+process.env against it. These tests cover the Python (writer/setup) side
+and a Node runtime check of the TS filtering logic.
+"""
+
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from dlab.parallel_tool import PARALLEL_AGENTS_SOURCE
+from dlab.session import (
+    INSTANCE_ENV_EXACT,
+    setup_opencode_config,
+    write_instance_env_allowlist,
+)
+
+REPO = Path(__file__).parent.parent
+
+
+class TestAllowlistWriter:
+    def test_writer_includes_operational_and_provider_vars(
+        self, tmp_path: Path
+    ) -> None:
+        opencode = tmp_path / ".opencode"
+        opencode.mkdir()
+        write_instance_env_allowlist(opencode)
+        allow = json.loads(
+            (opencode / "instance-env-allowlist.json").read_text()
+        )
+        # operational
+        assert "PATH" in allow["exact"]
+        assert "PYTHONPATH" in allow["exact"]
+        # provider credentials (from bundled models.dev list) — several families
+        assert "ANTHROPIC_API_KEY" in allow["exact"]
+        assert "GEMINI_API_KEY" in allow["exact"]
+        assert "OPENAI_API_KEY" in allow["exact"]
+        assert "AWS_SECRET_ACCESS_KEY" in allow["exact"]  # non _API_KEY name
+        # prefixes for dlab/opencode config + cloud families
+        assert "DLAB_" in allow["prefixes"]
+        assert "OPENCODE_" in allow["prefixes"]
+
+    def test_writer_excludes_ambient_host_junk(self, tmp_path: Path) -> None:
+        opencode = tmp_path / ".opencode"
+        opencode.mkdir()
+        write_instance_env_allowlist(opencode)
+        allow = json.loads(
+            (opencode / "instance-env-allowlist.json").read_text()
+        )
+        for junk in ("HISTFILE", "SSH_AUTH_SOCK", "MY_BANK_PASSWORD"):
+            assert junk not in allow["exact"]
+        # No prefix should match generic shell/secret junk either.
+        assert not any("HIST".startswith(p) for p in allow["prefixes"])
+
+
+class TestSetupWritesAllowlist:
+    def test_setup_opencode_config_emits_allowlist_for_parallel_pack(
+        self, tmp_path: Path
+    ) -> None:
+        """A pack with parallel_agents/ must get the allowlist during setup,
+        next to the generated parallel-agents.ts."""
+        poem = REPO / "decision-packs" / "poem"
+        if not poem.exists():
+            pytest.skip("poem decision-pack not present")
+        wd = tmp_path / "work"
+        wd.mkdir()
+        setup_opencode_config(
+            config_dir=str(poem),
+            work_dir=str(wd),
+            orchestrator_model="google/gemini-2.5-flash",
+        )
+        allow_file = wd / ".opencode" / "instance-env-allowlist.json"
+        ts_file = wd / ".opencode" / "tools" / "parallel-agents.ts"
+        assert ts_file.exists(), "parallel-agents.ts not generated"
+        assert allow_file.exists(), "allowlist not written alongside the tool"
+
+
+class TestSourceUsesCuratedEnv:
+    def test_no_bare_process_env_passed_to_spawn(self) -> None:
+        """Regression guard for #56: instances/consolidator must not be
+        spawned with the full host environment."""
+        assert "env: process.env" not in PARALLEL_AGENTS_SOURCE
+        assert PARALLEL_AGENTS_SOURCE.count("env: buildInstanceEnv(cwd)") == 2
+
+    def test_builder_reads_the_allowlist(self) -> None:
+        assert "function buildInstanceEnv" in PARALLEL_AGENTS_SOURCE
+        assert "instance-env-allowlist.json" in PARALLEL_AGENTS_SOURCE
+
+
+class TestBuildInstanceEnvRuntime:
+    """Run the ACTUAL buildInstanceEnv logic (sliced from source, TS types
+    stripped) under Node against a hostile environment."""
+
+    def _extract_js(self) -> str:
+        src = PARALLEL_AGENTS_SOURCE
+        start = src.index("const FALLBACK_ENV_EXACT")
+        end = src.index("\n}", src.index("function buildInstanceEnv")) + 2
+        block = src[start:end]
+        # Strip the few TS annotations present in this block.
+        block = block.replace(
+            "function buildInstanceEnv(cwd: string): Record<string, string>",
+            "function buildInstanceEnv(cwd)",
+        )
+        block = block.replace(
+            "const out: Record<string, string> = {}", "const out = {}"
+        )
+        block = block.replace("(p: string)", "(p)")
+        return block
+
+    def test_filters_hostile_env(self, tmp_path: Path) -> None:
+        if not _have_node():
+            pytest.skip("node not available")
+        opencode = tmp_path / ".opencode"
+        opencode.mkdir()
+        write_instance_env_allowlist(opencode)
+
+        driver = f"""
+const {{ readFileSync }} = require("fs");
+const {{ join }} = require("path");
+{self._extract_js()}
+process.env.ANTHROPIC_API_KEY = "sk-real";
+process.env.GEMINI_API_KEY = "g-real";
+process.env.DLAB_FIT_MODEL_LOCALLY = "1";
+process.env.PYTHONPATH = "/opt";
+process.env.MY_BANK_PASSWORD = "leak-me";
+process.env.HISTFILE = "/home/x/.zsh_history";
+const env = buildInstanceEnv({json.dumps(str(tmp_path))});
+const has = k => Object.prototype.hasOwnProperty.call(env, k);
+const ok = has("ANTHROPIC_API_KEY") && has("GEMINI_API_KEY")
+  && has("DLAB_FIT_MODEL_LOCALLY") && has("PYTHONPATH")
+  && !has("MY_BANK_PASSWORD") && !has("HISTFILE");
+process.exit(ok ? 0 : 1);
+"""
+        js = tmp_path / "driver.js"
+        js.write_text(driver)
+        result = subprocess.run(
+            ["node", str(js)], capture_output=True, text=True, timeout=15
+        )
+        assert result.returncode == 0, (
+            f"buildInstanceEnv did not filter correctly\n{result.stderr}"
+        )
+
+
+def _have_node() -> bool:
+    try:
+        subprocess.run(["node", "--version"], capture_output=True, timeout=5)
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False


### PR DESCRIPTION
## Problem

`[audit]` #56: parallel instances and the consolidator were spawned with `env: process.env` — the entire parent environment. In `--no-sandboxing` local mode the parent is the user's shell, so a subagent (which can run `bash`) could read shell-history paths and ambient secrets that have nothing to do with its task.

## Fix — Python owns the knowledge, TS does the filtering

A hardcoded TS allowlist would drift from models.dev and silently break auth for providers it doesn't anticipate (105 providers, messy names — AWS/Azure/Vertex/GitHub tokens don't fit a clean suffix). So:

- **dlab** writes `.opencode/instance-env-allowlist.json` at session setup (`write_instance_env_allowlist`): operational vars + the union of every LLM-provider credential in the bundled `KNOWN_PROVIDER_ENVS` + `DLAB_`/`OPENCODE_`/cloud-family prefixes.
- **parallel-agents.ts** `buildInstanceEnv()` reads it and filters `process.env`; both spawn sites use it. A conservative built-in fallback covers pre-existing workdirs resumed with `--continue-dir`.
- `HOME`/`PATH`/`PYTHONPATH` are kept (opencode config discovery + pack imports need them); the removed bulk is unrelated host state.

## Validation

- **Python**: unit test of the writer (provider keys present, host junk absent) + integration test that `setup_opencode_config` emits the allowlist for the poem pack.
- **Node runtime**: a test slices the *actual* `buildInstanceEnv` out of the source, runs it under `node` against a hostile env, and asserts it keeps `ANTHROPIC_API_KEY`/`GEMINI_API_KEY`/`PYTHONPATH`/`DLAB_*` and drops a planted `MY_BANK_PASSWORD` and `HISTFILE`.
- **End-to-end**: a full `--no-sandboxing` poem run with `MY_BANK_PASSWORD` exported into the parent — instances still authenticated to Gemini and produced `final_poem.md`, proving the curated env doesn't break auth (the real risk of over-filtering).

17 tests pass (new + existing parallel-tool suite).

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)