### PR TITLE
Fix #58: dedup TUI events by content, not timestamp alone

### DIFF
--- a/dlab/tui/models.py
+++ b/dlab/tui/models.py
@@ -345,8 +345,8 @@ class AgentState:
     is_complete : bool
         Cached flag: True once the agent's log file has been confirmed complete.
         Avoids re-parsing the entire log file on every timer tick.
-    _seen_timestamps : set[int]
-        Set of already-seen timestamps for O(1) duplicate detection.
+    _seen_keys : set[tuple[int, str, int]]
+        Set of already-seen event keys for O(1) duplicate detection.
     """
 
     name: str
@@ -356,14 +356,19 @@ class AgentState:
     start_time: datetime | None = None
     end_time: datetime | None = None
     is_complete: bool = False
-    _seen_timestamps: set[int] = field(default_factory=set, repr=False, compare=False)
+    _seen_keys: set[tuple[int, str, int]] = field(
+        default_factory=set, repr=False, compare=False
+    )
 
     def add_event(self, event: LogEvent) -> bool:
         """
         Add event and update computed state.
 
-        Deduplicates events based on timestamp to prevent duplicates
-        from watchdog firing multiple events.
+        Deduplicates events to absorb re-reads (e.g. the log file being
+        replaced/truncated, resetting the watcher to offset 0). The key is
+        the full event content, not the timestamp alone — two legitimately
+        distinct events can share a millisecond timestamp, and keying on
+        timestamp dropped the second one (issue #58).
 
         Parameters
         ----------
@@ -375,13 +380,20 @@ class AgentState:
         bool
             True if event was added, False if it was a duplicate.
         """
-        # Deduplicate based on timestamp (events with same timestamp are duplicates).
+        # Deduplicate on (timestamp, event_type, content-hash-of-raw-line).
+        # The raw JSON of the source line distinguishes two same-millisecond
+        # events; a byte-identical re-read collapses to the same key.
         # Skip deduplication for timestamp=0 events (raw_text, additional_output).
-        # O(1) set lookup instead of O(n) linear scan.
         if event.timestamp > 0:
-            if event.timestamp in self._seen_timestamps:
+            content_hash: int = hash(
+                json.dumps(event.raw, sort_keys=True, default=str)
+            )
+            key: tuple[int, str, int] = (
+                event.timestamp, event.event_type, content_hash,
+            )
+            if key in self._seen_keys:
                 return False
-            self._seen_timestamps.add(event.timestamp)
+            self._seen_keys.add(key)
 
         self.events.append(event)
         self.total_cost += event.cost

--- a/tests/test_tui_render_followups.py
+++ b/tests/test_tui_render_followups.py
@@ -22,14 +22,31 @@ def _event(timestamp: int, event_type: str, **part: object) -> LogEvent:
 
 
 class TestAddEventDedup:
-    """AgentState.add_event deduplicates by timestamp via the _seen set."""
+    """AgentState.add_event collapses re-read duplicates but keeps distinct
+    events, including two that share a millisecond timestamp (issue #58)."""
 
-    def test_duplicate_timestamp_rejected(self) -> None:
+    def test_identical_event_rejected_as_reread(self) -> None:
+        # Same timestamp AND same content = a re-read (e.g. file replaced,
+        # watcher reset to offset 0). Must be dropped.
         state = AgentState(name="agent")
         assert state.add_event(_event(100, "text", text="a")) is True
-        # Same timestamp -> treated as a duplicate, not added again.
-        assert state.add_event(_event(100, "text", text="b")) is False
+        assert state.add_event(_event(100, "text", text="a")) is False
         assert len(state.events) == 1
+
+    def test_distinct_events_same_timestamp_both_kept(self) -> None:
+        # The #58 bug: two legitimately different events in the same
+        # millisecond. Both must be kept, not collapsed to one.
+        state = AgentState(name="agent")
+        assert state.add_event(_event(100, "text", text="a")) is True
+        assert state.add_event(_event(100, "text", text="b")) is True
+        assert len(state.events) == 2
+
+    def test_same_timestamp_different_type_both_kept(self) -> None:
+        # e.g. a step_finish and the following step_start in the same ms.
+        state = AgentState(name="agent")
+        assert state.add_event(_event(100, "step_finish")) is True
+        assert state.add_event(_event(100, "step_start")) is True
+        assert len(state.events) == 2
 
     def test_distinct_timestamps_kept(self) -> None:
         state = AgentState(name="agent")


### PR DESCRIPTION
## Problem

`[audit]` #58: `AgentState.add_event` deduplicated on the millisecond timestamp alone. Two legitimately distinct events that share a millisecond — a `step_finish` and the next `step_start`, or two rapid tool events — collided, and the second was silently dropped. This happens in the **normal ingestion path**, not just on re-read, so any co-millisecond pair lost an event from the TUI (and would corrupt the per-agent event counters the upcoming session digest, #68, is built on).

## Why dedup exists at all

The watcher tracks byte offsets (`seek`/`tell`) and normally reads only new content, so `add_event`'s dedup is the secondary net for the file-replacement/truncation case (offset resets to 0 → whole file re-emitted). The fix preserves that: a byte-identical re-read still collapses.

## Fix

Key on `(timestamp, event_type, hash(json.dumps(raw, sort_keys=True)))`. The raw JSON line distinguishes two same-millisecond events; an identical re-read hashes the same and is dropped. `timestamp == 0` events (raw_text / additional_output) remain exempt as before.

## Tests

The existing dedup test asserted the *bug* (two different-content events at the same ts → second rejected). Rewrote the class: an identical re-read is rejected; distinct same-ts events, both by content and by event_type, are both kept; distinct timestamps and zero-timestamp exemption still hold. 11 passing in the followup file; 71 across parser + TUI suites.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)