### PR TITLE
Audit fixes: empty-log timeline, pixi PATH, continue-dir non-interactive, log-complete reasons

### DIFF
--- a/dlab/cli.py
+++ b/dlab/cli.py
@@ -217,6 +217,13 @@ def _main(
             help="Run opencode locally without Docker (no container isolation)",
         ),
     ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            help="Auto-confirm interactive prompts (e.g. --continue-dir without --work-dir)",
+        ),
+    ] = False,
 ) -> None:
     """Run opencode in automated mode, sandboxed with Docker."""
     if ctx.resilient_parsing:
@@ -237,6 +244,7 @@ def _main(
             rebuild=rebuild,
             env_file=env_file,
             no_sandboxing=no_sandboxing,
+            yes=yes,
         )
         raise typer.Exit(code=exit_code)
 
@@ -255,6 +263,7 @@ def cmd_run(
     rebuild: bool = False,
     env_file: str | None = None,
     no_sandboxing: bool = False,
+    yes: bool = False,
 ) -> int:
     """
     Handle run mode - create session and start agent.
@@ -389,13 +398,17 @@ def cmd_run(
             work_dir = str(work_path)
             print(f"Copied {_continue_dir} to {work_dir}")
         else:
-            # Continue in place - ask for confirmation
+            # Continue in place - ask for confirmation in interactive mode
             work_dir = str(_continue_dir)
             print(f"Will continue session in: {work_dir}")
-            confirm = input("Continue? [y/N]: ").strip().lower()
-            if confirm != "y":
-                print("Aborted.")
-                return 0
+            if yes or not sys.stdin.isatty():
+                # Auto-confirm when --yes is passed or stdin is not a TTY
+                pass
+            else:
+                confirm = input("Continue? [y/N]: ").strip().lower()
+                if confirm != "y":
+                    print("Aborted.")
+                    return 0
 
         # Overwrite .opencode with latest from decision-pack (agent prompts may have changed)
         opencode_dir = Path(work_dir) / ".opencode"

--- a/dlab/create_dpack.py
+++ b/dlab/create_dpack.py
@@ -477,12 +477,11 @@ def _build_dockerfile(config: dict[str, Any]) -> str:
             "RUN apt-get update && apt-get install -y curl && \\",
             "    curl -fsSL https://pixi.sh/install.sh | bash && \\",
             "    rm -rf /var/lib/apt/lists/*",
-            'ENV PATH="/root/.pixi/bin:$PATH"',
             "",
             "# Install pixi packages to /opt/pixi (not /workspace, which gets volume-mounted)",
             "COPY pixi.toml /opt/pixi/pixi.toml",
             "RUN cd /opt/pixi && pixi install",
-            'ENV PATH="/opt/pixi/.pixi/envs/default/bin:$PATH"',
+            'ENV PATH="/opt/pixi/.pixi/envs/default/bin:/root/.pixi/bin:$PATH"',
             "",
         ])
     else:  # pip

--- a/dlab/opencode_logparser.py
+++ b/dlab/opencode_logparser.py
@@ -232,7 +232,8 @@ def is_log_complete(events: list[LogEvent]) -> bool:
     Check if a list of events represents a completed run.
 
     A log is complete if:
-    - Its last step_finish event has reason "stop" or "error", OR
+    - Its last step_finish event has reason "stop", "error", "max-tokens",
+      or "tool-calls", OR
     - It contains an "error" event (job crashed/terminated)
 
     Parameters
@@ -264,7 +265,7 @@ def is_log_complete(events: list[LogEvent]) -> bool:
         return False
 
     reason: str = last_step_finish.part.get("reason", "")
-    return reason in ("stop", "error")
+    return reason in ("stop", "error", "max-tokens", "tool-calls")
 
 
 def is_log_file_complete(path: str | Path) -> bool:

--- a/dlab/timeline.py
+++ b/dlab/timeline.py
@@ -315,6 +315,11 @@ def build_timeline(
                 "idle_periods": idle_periods_by_source.get(source_name, []),
             }
 
+    # All log files were empty
+    if not file_summaries:
+        print(f"All .log files in {logs_dir} are empty", file=sys.stderr)
+        return {}
+
     # Sort all events by timestamp
     all_events.sort(key=lambda e: e["timestamp"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,7 @@ class TestContinueDir:
         prompt: str = "continue",
         no_sandboxing: bool = False,
         data: list[str] | None = None,
+        yes: bool = False,
     ) -> int:
         """Helper to run cmd_run in continue mode, mocking agent execution."""
         mock_return = (0, "", "")
@@ -407,6 +408,7 @@ class TestContinueDir:
                 work_dir=str(work_dir) if work_dir else None,
                 no_sandboxing=no_sandboxing,
                 data=data,
+                yes=yes,
             )
 
     # --- Error handling (no mode needed, errors before execution) ---
@@ -460,6 +462,43 @@ class TestContinueDir:
         assert result == 1
         captured = capsys.readouterr()
         assert "already exists" in captured.out
+
+    def test_continue_yes_flag_skips_prompt(
+        self,
+        dpack_config_dir: Path,
+        previous_session: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--yes should auto-confirm --continue-dir without --work-dir."""
+        result: int = self._run_continue(
+            dpack_config_dir,
+            previous_session,
+            yes=True,
+            no_sandboxing=True,
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Will continue session in:" in captured.out
+        assert "Aborted." not in captured.out
+
+    def test_continue_non_tty_auto_confirms(
+        self,
+        dpack_config_dir: Path,
+        previous_session: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-interactive mode (no TTY) should auto-confirm continue."""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        result: int = self._run_continue(
+            dpack_config_dir,
+            previous_session,
+            no_sandboxing=True,
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Will continue session in:" in captured.out
+        assert "Aborted." not in captured.out
 
     # --- Local mode (--no-sandboxing) ---
 

--- a/tests/test_create_dpack.py
+++ b/tests/test_create_dpack.py
@@ -577,6 +577,17 @@ class TestDockerfilePerPackageManager:
         assert "pixi install" in content
         assert 'CMD ["/bin/bash"]' in content
 
+    def test_pixi_dockerfile_single_path_definition(self, tmp_path: Path) -> None:
+        """pixi Dockerfile should have exactly one ENV PATH line with both paths (#3)."""
+        config: dict[str, Any] = {"name": "pixi-path-test", "package_manager": "pixi"}
+        generate_dpack(tmp_path, config)
+
+        content: str = (tmp_path / "pixi-path-test" / "docker" / "Dockerfile").read_text()
+        env_lines = [l for l in content.splitlines() if "ENV PATH=" in l]
+        assert len(env_lines) == 1, f"Expected 1 ENV PATH line, got {len(env_lines)}"
+        assert "/opt/pixi/.pixi/envs/default/bin" in env_lines[0]
+        assert "/root/.pixi/bin" in env_lines[0]
+
     def test_default_package_manager_is_pip(self, tmp_path: Path) -> None:
         """Default package manager should be pip."""
         generate_dpack(tmp_path, {"name": "default-pkg"})

--- a/tests/test_opencode_logparser.py
+++ b/tests/test_opencode_logparser.py
@@ -359,12 +359,19 @@ class TestIsLogComplete:
         ]
         assert is_log_complete(events) is True
 
-    def test_running_tool_calls(self) -> None:
+    def test_complete_tool_calls(self) -> None:
         events: list[LogEvent] = [
             LogEvent("step_start", 1000, "", {}, {}),
             LogEvent("step_finish", 2000, "", {"reason": "tool-calls"}, {}),
         ]
-        assert is_log_complete(events) is False
+        assert is_log_complete(events) is True
+
+    def test_complete_max_tokens(self) -> None:
+        events: list[LogEvent] = [
+            LogEvent("step_start", 1000, "", {}, {}),
+            LogEvent("step_finish", 2000, "", {"reason": "max-tokens"}, {}),
+        ]
+        assert is_log_complete(events) is True
 
     def test_error_event(self) -> None:
         events: list[LogEvent] = [
@@ -388,10 +395,10 @@ class TestIsLogComplete:
         log_file.write_text(f"{STEP_START_LINE}\n{STEP_FINISH_LINE}\n")
         assert is_log_file_complete(log_file) is True
 
-    def test_file_running(self, tmp_path: Path) -> None:
-        log_file: Path = tmp_path / "running.log"
+    def test_file_complete_tool_calls(self, tmp_path: Path) -> None:
+        log_file: Path = tmp_path / "tool_calls.log"
         log_file.write_text(f"{STEP_START_LINE}\n{STEP_FINISH_TOOL_CALLS_LINE}\n")
-        assert is_log_file_complete(log_file) is False
+        assert is_log_file_complete(log_file) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,28 @@
+"""Tests for dlab.timeline module."""
+
+from pathlib import Path
+
+import pytest
+
+from dlab.timeline import build_timeline
+
+
+class TestBuildTimeline:
+    """Tests for build_timeline."""
+
+    def test_empty_log_dir(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Should return empty dict when no log files exist."""
+        result = build_timeline(tmp_path, is_running=False)
+        assert result == {}
+        captured = capsys.readouterr()
+        assert "No .log files found" in captured.err
+
+    def test_all_empty_log_files(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Should return empty dict when all log files are empty (#1)."""
+        (tmp_path / "agent1.log").write_text("")
+        (tmp_path / "agent2.log").write_text("")
+        result = build_timeline(tmp_path, is_running=False)
+        assert result == {}
+        captured = capsys.readouterr()
+        assert "All .log files" in captured.err
+        assert "are empty" in captured.err


### PR DESCRIPTION
*(Opened by Claude on Ben's behalf, bundling the audit agent's completed fixes for merge — the agent was paused for this.)*

Four small, independently-tested fixes from the `[audit]` sweep (the agent's internal AUDIT.md numbering `#1`/`#3` map to GitHub issues #40/#42):

- **#50** — `is_log_complete` now treats `max-tokens` and `tool-calls` step-finish reasons as terminal, so the TUI stops showing a perpetual running dot for sessions that hit the token limit or ended on tool calls.
- **#49** — `--continue-dir` in-place continuation auto-confirms when stdin is not a TTY, and a `--yes` flag is added for explicit auto-confirm (previously it blocked forever on `input()` in non-interactive runs).
- **#40** — `build_timeline` returns cleanly (with a stderr note) when all log files are empty, instead of crashing.
- **#42** — the pixi Dockerfile consolidates its two `ENV PATH` lines into one (the second previously shadowed the first, dropping `/root/.pixi/bin`).

## Verification

Merges cleanly into current main (no conflicts, incl. the `opencode_logparser.py` overlap with the recently-merged #61). Full non-Docker suite green on the merged tree: **421 passed**. Each fix ships with tests.

Closes #40. Closes #42. Closes #49. Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)