### PR TITLE
Fix #51: model fallback only rewrites .md frontmatter, not prompt bodies

### DIFF
--- a/dlab/model_fallback.py
+++ b/dlab/model_fallback.py
@@ -280,13 +280,38 @@ def preflight_check(
     return errors, warnings
 
 
+def _split_frontmatter(text: str) -> tuple[str, str, str] | None:
+    """
+    Split a markdown document into (opening, frontmatter, remainder).
+
+    Returns None if the text has no leading YAML frontmatter block (a ``---``
+    line, some content, and a closing ``---`` line). ``opening`` is the first
+    ``---`` line, ``frontmatter`` is the inner YAML, and ``remainder`` is the
+    closing ``---`` line plus the document body.
+    """
+    lines: list[str] = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\n") != "---":
+        return None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\n") == "---":
+            return lines[0], "".join(lines[1:i]), "".join(lines[i:])
+    return None
+
+
 def apply_model_fallback(
     text: str,
     orchestrator_model: str,
     unavailable_providers: set[str],
+    is_markdown: bool = False,
 ) -> tuple[str, list[str]]:
     """
     Replace model strings whose providers are unavailable.
+
+    For markdown agent files (``is_markdown=True``) only the YAML frontmatter
+    is rewritten; the body is left untouched. Model-like strings in an agent
+    prompt's prose, code blocks, URLs, or examples are not live configuration
+    and must never be rewritten (issue #51). For YAML files the whole file is
+    configuration, so all non-comment lines are processed.
 
     Parameters
     ----------
@@ -296,6 +321,9 @@ def apply_model_fallback(
         Model to substitute in place of unavailable ones.
     unavailable_providers : set[str]
         Provider names whose API keys are missing.
+    is_markdown : bool
+        True if ``text`` is a markdown (.md) agent file; only its frontmatter
+        is treated as configuration.
 
     Returns
     -------
@@ -315,15 +343,24 @@ def apply_model_fallback(
             return orchestrator_model
         return model_str
 
-    # Only replace on non-comment lines
-    new_lines: list[str] = []
-    for line in text.splitlines(keepends=True):
-        if line.lstrip().startswith("#"):
-            new_lines.append(line)
-        else:
-            new_lines.append(_MODEL_PATTERN.sub(_replace, line))
+    def _process(region: str) -> str:
+        out: list[str] = []
+        for line in region.splitlines(keepends=True):
+            if line.lstrip().startswith("#"):
+                out.append(line)
+            else:
+                out.append(_MODEL_PATTERN.sub(_replace, line))
+        return "".join(out)
 
-    return "".join(new_lines), replacements
+    if is_markdown:
+        parts: tuple[str, str, str] | None = _split_frontmatter(text)
+        if parts is None:
+            # No frontmatter — the whole file is prose/examples, never config.
+            return text, []
+        opening, frontmatter, remainder = parts
+        return opening + _process(frontmatter) + remainder, replacements
+
+    return _process(text), replacements
 
 
 def process_opencode_dir(
@@ -382,7 +419,7 @@ def process_opencode_dir(
     for f in config_files:
         text: str = f.read_text()
         new_text, replacements = apply_model_fallback(
-            text, orchestrator_model, unavailable,
+            text, orchestrator_model, unavailable, is_markdown=f.suffix == ".md",
         )
         if replacements:
             f.write_text(new_text)

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -349,6 +349,75 @@ class TestApplyModelFallback:
         assert len(replacements) == 1
 
 
+class TestMarkdownFallbackScope:
+    """apply_model_fallback with is_markdown=True only rewrites frontmatter,
+    never the prompt body (issue #51: no false replacements in prose, code
+    blocks, URLs, or examples)."""
+
+    OPTS = ("anthropic/claude-opus-4-0", {"google", "openai"})
+
+    def test_frontmatter_model_replaced(self) -> None:
+        text: str = textwrap.dedent("""\
+            ---
+            mode: primary
+            model: google/gemini-2.5-pro
+            ---
+            body
+        """)
+        new_text, reps = apply_model_fallback(text, *self.OPTS, is_markdown=True)
+        assert "model: anthropic/claude-opus-4-0" in new_text
+        assert len(reps) == 1
+
+    def test_body_prose_not_replaced(self) -> None:
+        text: str = textwrap.dedent("""\
+            ---
+            mode: primary
+            ---
+            Unlike google/gemini-2.5-pro, our approach uses openai/gpt-4 sparingly.
+        """)
+        new_text, reps = apply_model_fallback(text, *self.OPTS, is_markdown=True)
+        assert new_text == text
+        assert reps == []
+
+    def test_body_code_block_not_replaced(self) -> None:
+        text: str = textwrap.dedent("""\
+            ---
+            mode: primary
+            ---
+            Example config:
+            ```yaml
+            default_model: "google/gemini-2.5-pro"
+            ```
+        """)
+        new_text, reps = apply_model_fallback(text, *self.OPTS, is_markdown=True)
+        assert '"google/gemini-2.5-pro"' in new_text
+        assert reps == []
+
+    def test_body_url_not_replaced(self) -> None:
+        text: str = textwrap.dedent("""\
+            ---
+            mode: primary
+            ---
+            See https://example.com/openai/gpt-4-guide for details.
+        """)
+        new_text, reps = apply_model_fallback(text, *self.OPTS, is_markdown=True)
+        assert new_text == text
+
+    def test_no_frontmatter_means_no_replacement(self) -> None:
+        # A skill doc with no frontmatter is all prose/examples.
+        text: str = 'Set default_model: "google/gemini-2.5-pro" in config.yaml.\n'
+        new_text, reps = apply_model_fallback(text, *self.OPTS, is_markdown=True)
+        assert new_text == text
+        assert reps == []
+
+    def test_yaml_still_fully_processed(self) -> None:
+        # is_markdown=False (a .yaml file): value replaced as before.
+        text: str = 'default_model: "google/gemini-2.5-pro"\n'
+        new_text, reps = apply_model_fallback(text, *self.OPTS, is_markdown=False)
+        assert "google/" not in new_text
+        assert len(reps) == 1
+
+
 class TestProcessOpencodeDir:
     """Tests for process_opencode_dir()."""
 
@@ -394,15 +463,18 @@ class TestProcessOpencodeDir:
         assert "anthropic/claude-opus-4-0" in content
         assert any("-> " in msg for msg in result)
 
-    def test_fallback_replaces_in_markdown(self, tmp_path: Path) -> None:
+    def test_fallback_replaces_md_frontmatter_only(self, tmp_path: Path) -> None:
+        # Issue #51: a .md agent file's frontmatter model is replaced, but a
+        # model mentioned in the prompt BODY (example / prose) is left intact.
         opencode_dir: Path = tmp_path / ".opencode"
         agents_dir: Path = opencode_dir / "agents"
         agents_dir.mkdir(parents=True)
         (agents_dir / "orchestrator.md").write_text(textwrap.dedent("""\
             ---
             mode: primary
+            model: google/gemini-2.5-pro
             ---
-            Use "models": ["google/gemini-2.5-pro"]
+            Example call: parallel-agents with "google/gemini-2.5-pro".
         """))
         env_file: Path = tmp_path / ".env"
         env_file.write_text("ANTHROPIC_API_KEY=sk-123\n")
@@ -411,8 +483,10 @@ class TestProcessOpencodeDir:
             str(opencode_dir), "anthropic/claude-opus-4-0", str(env_file),
         )
         content: str = (agents_dir / "orchestrator.md").read_text()
-        assert "google/" not in content
-        assert "anthropic/claude-opus-4-0" in content
+        # Frontmatter model was replaced ...
+        assert "model: anthropic/claude-opus-4-0" in content
+        # ... but the body example was not touched.
+        assert '"google/gemini-2.5-pro"' in content
 
     def test_skips_when_orchestrator_key_missing(self, tmp_path: Path) -> None:
         opencode_dir: Path = tmp_path / ".opencode"
@@ -453,7 +527,9 @@ class TestProcessOpencodeDir:
         )
         yaml_content: str = (pa_dir / "modeler.yaml").read_text()
         md_content: str = (agents_dir / "orchestrator.md").read_text()
+        # YAML config is fully rewritten ...
         assert "google/" not in yaml_content
-        assert "google/" not in md_content
         assert yaml_content.count("anthropic/claude-opus-4-0") == 2
-        assert md_content.count("anthropic/claude-opus-4-0") == 1
+        # ... but the .md body prose is left intact (issue #51).
+        assert "google/gemini-2.5-pro" in md_content
+        assert "anthropic/claude-opus-4-0" not in md_content


### PR DESCRIPTION
## Problem

`[audit]` #51 (Serious): `apply_model_fallback` rewrote **any** `provider/model` token on any non-`#`-comment line of every scanned file. In agent and skill `.md` files that includes the prompt **body** — so a model string in prose, a fenced code-block example, a URL, or a doc snippet got silently rewritten to the orchestrator's model, corrupting the prompt. (`_strip_comments` only handled `#` lines, not markdown code blocks / comments / URLs.)

## Fix

Every false-positive case lives in the `.md` **body**; real model declarations in agent files live only in the YAML **frontmatter** (parallel-agent configs are `.yaml`). So:

- `apply_model_fallback` gains `is_markdown`. For `.md`, only the frontmatter block is processed; the body is returned untouched (and a `.md` with no frontmatter is treated as all-prose → no replacement).
- `.yaml`/`.yml` files are unchanged — the whole file is configuration.
- `process_opencode_dir` passes `is_markdown=(f.suffix == ".md")`.

`find_model_strings` (the detection/validation path) is left liberal on purpose — the serious bug was false *replacements* that corrupt prompts, not detection.

## Tests

Two `process_opencode_dir` tests previously asserted the **buggy** body-replacement behavior; rewritten to assert frontmatter-replaced / body-preserved. New `TestMarkdownFallbackScope`: frontmatter `model:` replaced; body prose, fenced code block, URL, and no-frontmatter cases all left intact; YAML still fully processed. 84 passing across the fallback + session suites.

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)