### PR TITLE
Fix #55 + #48: bound artifact reads by size; card (not garbled text) for large/binary files

### DIFF
--- a/dlab/tui/widgets/artifacts_pane.py
+++ b/dlab/tui/widgets/artifacts_pane.py
@@ -26,6 +26,10 @@ from textual.widgets import DataTable, ListItem, ListView, Static
 # File extensions to include as artifacts
 ARTIFACT_EXTENSIONS = {".md", ".py", ".txt", ".csv", ".png", ".jpg", ".jpeg", ".pdf"}
 
+# Files larger than this are not read into memory for preview (issue #55);
+# a metadata card with an "open externally" hint is shown instead.
+MAX_PREVIEW_BYTES = 5 * 1024 * 1024
+
 # Directories to exclude from artifact discovery
 EXCLUDE_DIRS = {
     ".git",
@@ -416,6 +420,15 @@ class FileViewer(VerticalScroll, can_focus=True):
             self.mount(PdfDisplay(path))
             return
 
+        # Too large to preview safely — show a metadata card instead of
+        # reading the whole file into memory (issue #55).
+        try:
+            if path.stat().st_size > MAX_PREVIEW_BYTES:
+                self.mount(LargeFileDisplay(path))
+                return
+        except OSError:
+            pass
+
         # Read text content
         try:
             content = path.read_text(encoding="utf-8", errors="replace")
@@ -568,6 +581,41 @@ class PdfDisplay(Static):
 
     def _open_file(self) -> None:
         """Open the file in system default viewer."""
+        open_file_externally(self._path)
+
+
+class LargeFileDisplay(Static):
+    """Metadata card for a file too large to preview inline (issue #55)."""
+
+    def __init__(self, path: Path, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._path = path
+
+    def render(self) -> Text:
+        if not self._path.exists():
+            return Text(f"File not found: {self._path}", style="red")
+
+        size: int = self._path.stat().st_size
+        size_str: str = (
+            f"{size / (1024 * 1024):.1f} MB"
+            if size >= 1024 * 1024
+            else f"{size / 1024:.1f} KB"
+        )
+
+        text = Text()
+        text.append(f"{self._path.name}\n\n", style="bold")
+        text.append(f"Size: {size_str}\n", style="dim")
+        text.append("Too large to preview inline.\n\n", style="yellow")
+        text.append("Path: ", style="")
+        text.append(f"{self._path}", style="underline cyan")
+        text.append("\n\n")
+        text.append("Click path or press ", style="dim")
+        text.append("o", style="bold cyan")
+        text.append(" to open externally", style="dim")
+        return text
+
+    def on_click(self) -> None:
+        """Handle click - open the file externally."""
         open_file_externally(self._path)
 
 

--- a/dlab/tui/widgets/artifacts_pane.py
+++ b/dlab/tui/widgets/artifacts_pane.py
@@ -153,6 +153,32 @@ def is_parallel_run_dir(name: str) -> bool:
     return name == "parallel" or name.startswith("run-")
 
 
+def _looks_binary(path: Path) -> bool:
+    """
+    Heuristically decide whether a file is binary, reading only a bounded
+    prefix (never the whole file).
+
+    A file is treated as binary if the first 8 KB contains a NUL byte or is
+    not valid UTF-8. Used to show a metadata card instead of previewing
+    non-text files as garbled text (issue #48).
+    """
+    try:
+        with open(path, "rb") as f:
+            chunk: bytes = f.read(8192)
+    except OSError:
+        return False
+    if b"\x00" in chunk:
+        return True
+    try:
+        chunk.decode("utf-8")
+    except UnicodeDecodeError:
+        # A multibyte char split at the 8 KB boundary would also raise; that
+        # is rare and only misclassifies a borderline text file as binary,
+        # which merely shows a card — acceptable.
+        return True
+    return False
+
+
 def discover_artifacts(
     work_dir: Path, agent_dir: Path | None, is_main: bool = False
 ) -> list[Path]:
@@ -424,10 +450,16 @@ class FileViewer(VerticalScroll, can_focus=True):
         # reading the whole file into memory (issue #55).
         try:
             if path.stat().st_size > MAX_PREVIEW_BYTES:
-                self.mount(LargeFileDisplay(path))
+                self.mount(NonPreviewableDisplay(path, "Too large to preview inline."))
                 return
         except OSError:
             pass
+
+        # Binary (parquet, nc, pkl, ...) — a metadata card, not garbled text
+        # (issue #48). Images and PDFs were already handled above.
+        if _looks_binary(path):
+            self.mount(NonPreviewableDisplay(path, "Binary file — not previewable."))
+            return
 
         # Read text content
         try:
@@ -584,12 +616,15 @@ class PdfDisplay(Static):
         open_file_externally(self._path)
 
 
-class LargeFileDisplay(Static):
-    """Metadata card for a file too large to preview inline (issue #55)."""
+class NonPreviewableDisplay(Static):
+    """Metadata card for a file that is not previewed inline — because it is
+    too large (issue #55) or binary (issue #48). Shows name/size and an
+    open-externally hint instead of dumping bytes into the viewer."""
 
-    def __init__(self, path: Path, **kwargs) -> None:
+    def __init__(self, path: Path, reason: str, **kwargs) -> None:
         super().__init__(**kwargs)
         self._path = path
+        self._reason = reason
 
     def render(self) -> Text:
         if not self._path.exists():
@@ -605,7 +640,7 @@ class LargeFileDisplay(Static):
         text = Text()
         text.append(f"{self._path.name}\n\n", style="bold")
         text.append(f"Size: {size_str}\n", style="dim")
-        text.append("Too large to preview inline.\n\n", style="yellow")
+        text.append(f"{self._reason}\n\n", style="yellow")
         text.append("Path: ", style="")
         text.append(f"{self._path}", style="underline cyan")
         text.append("\n\n")

--- a/dlab/viewer/server.py
+++ b/dlab/viewer/server.py
@@ -204,6 +204,14 @@ def _collect_artifacts(
                 continue
 
             mime: str = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+            try:
+                size: int = file_path.stat().st_size
+            except OSError:
+                continue
+            if size > MAX_INLINE_BYTES:
+                # Too large to inline — list as metadata; served on demand via /file.
+                artifact_map[path_str] = {"type": "too_large", "size": size, "mime": mime}
+                continue
             if mime.startswith("text/") or mime in ("application/json",) or file_path.suffix in (".md", ".py", ".txt", ".csv"):
                 try:
                     content: str = file_path.read_text(encoding="utf-8", errors="replace")
@@ -302,6 +310,13 @@ def _inline_cdn_resources(html: str) -> str:
 
 
 CSV_MAX_ROWS: int = 1000
+
+# Artifacts larger than this are not inlined into the session JSON (issue #55).
+# They are listed as metadata only; the file itself is still served on demand
+# through the streaming /file endpoint. Inlining reads the whole file into
+# memory (and base64 inflates binaries ~33%), so a multi-GB artifact would OOM
+# the viewer at page load.
+MAX_INLINE_BYTES: int = 5 * 1024 * 1024
 
 
 def export_viewer(work_dir: Path, output_path: Path) -> int:

--- a/tests/test_large_artifacts.py
+++ b/tests/test_large_artifacts.py
@@ -1,8 +1,12 @@
-"""Tests for the large-artifact memory guards (issue #55)."""
+"""Tests for the large/binary artifact guards (issues #55, #48)."""
 
 from pathlib import Path
 
-from dlab.tui.widgets.artifacts_pane import MAX_PREVIEW_BYTES, LargeFileDisplay
+from dlab.tui.widgets.artifacts_pane import (
+    MAX_PREVIEW_BYTES,
+    NonPreviewableDisplay,
+    _looks_binary,
+)
 from dlab.viewer.server import MAX_INLINE_BYTES, _collect_artifacts
 
 
@@ -44,23 +48,59 @@ class TestCollectArtifactsSizeGuard:
         assert amap["plot.png"]["content"].startswith("data:")
 
 
-class TestLargeFileDisplay:
-    """The TUI shows a metadata card instead of reading an oversized file."""
+class TestNonPreviewableCard:
+    """The TUI shows a metadata card instead of reading oversized or binary
+    files (issues #55, #48)."""
 
-    def test_card_renders_without_reading_content(self, tmp_path: Path) -> None:
+    def test_too_large_card(self, tmp_path: Path) -> None:
         big = tmp_path / "predictions.parquet"
         big.write_bytes(b"\0" * (MAX_PREVIEW_BYTES + 10))
-        card = LargeFileDisplay(big)
-        rendered = card.render().plain
+        rendered = NonPreviewableDisplay(big, "Too large to preview inline.").render().plain
         assert "predictions.parquet" in rendered
         assert "Too large" in rendered
         assert "MB" in rendered
 
-    def test_show_file_gates_on_size(self) -> None:
-        # The preview path must check the size cap before read_text (#55).
+    def test_binary_card(self, tmp_path: Path) -> None:
+        f = tmp_path / "model.pkl"
+        f.write_bytes(b"\x80\x04\x00binary")
+        rendered = NonPreviewableDisplay(f, "Binary file — not previewable.").render().plain
+        assert "model.pkl" in rendered
+        assert "Binary" in rendered
+
+    def test_show_file_gates_on_size_and_binary(self) -> None:
+        # The preview path must check size AND binary before read_text.
         import inspect
         from dlab.tui.widgets import artifacts_pane
 
         src = inspect.getsource(artifacts_pane.FileViewer.show_file)
-        assert "MAX_PREVIEW_BYTES" in src
         assert src.index("MAX_PREVIEW_BYTES") < src.index("read_text")
+        assert src.index("_looks_binary") < src.index("read_text")
+
+
+class TestLooksBinary:
+    def test_small_parquet_is_binary(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.parquet"
+        f.write_bytes(b"PAR1\x00\x00\x01\x02\xff\xfe" + b"\x00" * 50)
+        assert _looks_binary(f) is True
+
+    def test_pickle_is_binary(self, tmp_path: Path) -> None:
+        f = tmp_path / "x.pkl"
+        f.write_bytes(b"\x80\x04\x95\x00\x00")
+        assert _looks_binary(f) is True
+
+    def test_text_types_are_not_binary(self, tmp_path: Path) -> None:
+        for name, content in (
+            ("a.json", '{"k": "v"}'),
+            ("a.csv", "col1,col2\n1,2\n"),
+            ("a.svg", "<svg></svg>"),
+            ("a.txt", "hello wörld"),  # non-ASCII but valid UTF-8
+        ):
+            f = tmp_path / name
+            f.write_text(content, encoding="utf-8")
+            assert _looks_binary(f) is False, name
+
+    def test_reads_only_a_bounded_prefix(self, tmp_path: Path) -> None:
+        # A NUL only past the 8 KB window is not scanned -> treated as text.
+        f = tmp_path / "big.txt"
+        f.write_bytes(b"a" * 8192 + b"\x00")
+        assert _looks_binary(f) is False

--- a/tests/test_large_artifacts.py
+++ b/tests/test_large_artifacts.py
@@ -1,0 +1,66 @@
+"""Tests for the large-artifact memory guards (issue #55)."""
+
+from pathlib import Path
+
+from dlab.tui.widgets.artifacts_pane import MAX_PREVIEW_BYTES, LargeFileDisplay
+from dlab.viewer.server import MAX_INLINE_BYTES, _collect_artifacts
+
+
+class TestCollectArtifactsSizeGuard:
+    """_collect_artifacts must not read oversized files into the session JSON."""
+
+    def _session(self, *paths: str) -> dict:
+        return {"tree": {"artifacts": [{"path": p} for p in paths]}}
+
+    def test_large_binary_not_inlined(self, tmp_path: Path) -> None:
+        big = tmp_path / "predictions.parquet"
+        big.write_bytes(b"\0" * (MAX_INLINE_BYTES + 1))
+        amap = _collect_artifacts(tmp_path, self._session("predictions.parquet"))
+        entry = amap["predictions.parquet"]
+        assert entry["type"] == "too_large"
+        assert entry["size"] > MAX_INLINE_BYTES
+        # Crucially, the file content was NOT read/encoded into the JSON.
+        assert "content" not in entry
+
+    def test_large_text_not_inlined(self, tmp_path: Path) -> None:
+        big = tmp_path / "huge.csv"
+        big.write_bytes(b"a,b\n" + b"1,2\n" * (MAX_INLINE_BYTES // 4))
+        amap = _collect_artifacts(tmp_path, self._session("huge.csv"))
+        assert amap["huge.csv"]["type"] == "too_large"
+        assert "content" not in amap["huge.csv"]
+
+    def test_small_file_still_inlined(self, tmp_path: Path) -> None:
+        small = tmp_path / "summary.txt"
+        small.write_text("all good")
+        amap = _collect_artifacts(tmp_path, self._session("summary.txt"))
+        assert amap["summary.txt"]["type"] == "text"
+        assert amap["summary.txt"]["content"] == "all good"
+
+    def test_small_binary_still_base64(self, tmp_path: Path) -> None:
+        img = tmp_path / "plot.png"
+        img.write_bytes(b"\x89PNG\r\n" + b"\0" * 100)
+        amap = _collect_artifacts(tmp_path, self._session("plot.png"))
+        assert amap["plot.png"]["type"] == "base64"
+        assert amap["plot.png"]["content"].startswith("data:")
+
+
+class TestLargeFileDisplay:
+    """The TUI shows a metadata card instead of reading an oversized file."""
+
+    def test_card_renders_without_reading_content(self, tmp_path: Path) -> None:
+        big = tmp_path / "predictions.parquet"
+        big.write_bytes(b"\0" * (MAX_PREVIEW_BYTES + 10))
+        card = LargeFileDisplay(big)
+        rendered = card.render().plain
+        assert "predictions.parquet" in rendered
+        assert "Too large" in rendered
+        assert "MB" in rendered
+
+    def test_show_file_gates_on_size(self) -> None:
+        # The preview path must check the size cap before read_text (#55).
+        import inspect
+        from dlab.tui.widgets import artifacts_pane
+
+        src = inspect.getsource(artifacts_pane.FileViewer.show_file)
+        assert "MAX_PREVIEW_BYTES" in src
+        assert src.index("MAX_PREVIEW_BYTES") < src.index("read_text")


### PR DESCRIPTION
Two related preview/memory guards for the viewer and TUI artifact panes.

## #55 — memory (reframed; see the issue)

`FileResponse` already streams and was **not** the bug. The real memory bomb is `_collect_artifacts` reading every artifact fully into the session JSON (base64-inflating binaries ~33%); the TUI had the same `read_text`-the-whole-file pattern.

- **viewer**: artifacts over `MAX_INLINE_BYTES` (5 MB) become `{"type": "too_large", size, mime}` metadata; served on demand via the streaming `/file` endpoint.
- **TUI**: files over `MAX_PREVIEW_BYTES` (5 MB) show a metadata card instead of being read.
- `FileResponse` unchanged.

## #48 (preview aspect) — no garbled binary

A newly-visible small binary (parquet/nc/pkl under 5 MB) previously rendered as `read_text` mojibake. Now `show_file` detects binary via `_looks_binary` (NUL byte / invalid UTF-8 in a bounded 8 KB prefix) and shows a **"Binary file — not previewable"** card. The too-large and binary cases share one `NonPreviewableDisplay` card (name, size, open-externally). Images and PDFs keep their dedicated previews; text (json/csv/svg/…) still renders.

(The artifact-**discovery** half of #48 — the "more files" expander that makes these binaries visible in the first place — is PR #78.)

## Tests

`tests/test_large_artifacts.py`: oversized artifacts become `too_large` metadata with no `content` (never read); small text/binary still inlined/base64; binary detection for parquet/pickle vs json/csv/svg/utf-8 text with a bounded-prefix check; both card variants render; `show_file` gates on size and binary before `read_text`. 55 passing with the viewer suite.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)