### PR TITLE
Audit small batch: spinner thread leak (#52), copyWorkDir excludes (#59), test comment (#67)

### DIFF
--- a/dlab/cli.py
+++ b/dlab/cli.py
@@ -127,8 +127,12 @@ def _run_with_log_spinner(
         ticker = threading.Thread(target=_tick, daemon=True)
         ticker.start()
 
-        result = run_fn()
-        running = False
+        try:
+            result = run_fn()
+        finally:
+            # Always stop the counter/ticker threads, even if run_fn raises,
+            # so they don't spin until process exit (issue #52).
+            running = False
 
     return result
 

--- a/dlab/js/parallel-agents.ts
+++ b/dlab/js/parallel-agents.ts
@@ -274,7 +274,14 @@ export default tool({
 
       // Copy entire work directory to instance (excluding special dirs)
       // This gives subagents access to all work done by the orchestrator so far
-      copyWorkDir(cwd, instanceDir, [".opencode", "_opencode_logs", "parallel", ".state.json", ".git"])
+      // Data files ARE copied (an instance may need them); but skip session
+      // internals and heavy regenerable caches/envs so each instance copy stays
+      // cheap (issue #59).
+      copyWorkDir(cwd, instanceDir, [
+        ".opencode", "_opencode_logs", "parallel", ".state.json", ".git",
+        "node_modules", ".venv", "venv", "__pycache__", ".pixi", ".conda",
+        ".mypy_cache", ".pytest_cache", ".ruff_cache",
+      ])
 
       // Copy .opencode with ONLY allowed tools
       copyAllowedTools(join(cwd, ".opencode"), join(instanceDir, ".opencode"), args.agent)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,7 +292,9 @@ class TestCmdRun:
             prompt="test prompt",
             work_dir=str(tmp_path / "work"),
         )
-        # opencode runs but fails (no API key / invalid model) — exit code 0
+        # The session lifecycle completed (image built, container ran opencode,
+        # cleanup ran), so cmd_run returns 0. opencode's own agent failing for
+        # lack of an API key is not a dlab session failure (issue #67).
         assert result == 0
 
         captured = capsys.readouterr()
@@ -320,7 +322,8 @@ class TestCmdRun:
             prompt_file=str(prompt_file),
             work_dir=str(tmp_path / "work"),
         )
-        # opencode runs but fails (no API key) — exit code 0
+        # exit 0: the session lifecycle completed; opencode's agent failing
+        # for lack of an API key is not a dlab session failure (issue #67).
         assert result == 0
 
     def test_run_uses_default_model(
@@ -924,3 +927,14 @@ class TestCLIIntegration:
         assert "No such option: --dpack" not in result.stderr
         assert "No such option: --data" not in result.stderr
         assert "No such option: --prompt" not in result.stderr
+
+
+def test_spinner_stops_threads_on_exception() -> None:
+    """_run_with_log_spinner must stop its threads even if run_fn raises (#52)."""
+    import inspect
+    from dlab import cli
+
+    src = inspect.getsource(cli._run_with_log_spinner)
+    assert "finally:" in src
+    # the running=False reset lives in the finally block, after run_fn()
+    assert src.index("run_fn()") < src.index("finally:") < src.rindex("running = False")

--- a/tests/test_parallel_tool.py
+++ b/tests/test_parallel_tool.py
@@ -182,3 +182,16 @@ class TestYamlImportRuntime:
         assert 'require("yaml")' in PARALLEL_AGENTS_SOURCE, (
             "parallel-agents.ts must use require('yaml') for CJS/ESM compatibility"
         )
+
+
+class TestInstanceCopyExcludes:
+    """copyWorkDir must skip heavy regenerable dirs but keep data (issue #59)."""
+
+    def test_excludes_caches_and_envs(self) -> None:
+        for name in ("node_modules", ".venv", "__pycache__", ".pixi", ".conda"):
+            assert f'"{name}"' in PARALLEL_AGENTS_SOURCE, name
+
+    def test_does_not_exclude_data_dir(self) -> None:
+        # The exclude list passed to copyWorkDir must not contain "data".
+        block = PARALLEL_AGENTS_SOURCE.split("copyWorkDir(cwd, instanceDir, [")[1].split("])")[0]
+        assert '"data"' not in block


### PR DESCRIPTION
Three small, independent audit fixes.

- **#52** — `_run_with_log_spinner` now wraps `run_fn()` in `try/finally`, so the counter/ticker threads are always stopped even when `run_fn` raises (previously they'd spin until process exit).
- **#59** — parallel instance `copyWorkDir` also excludes `node_modules`, `.venv`, `venv`, `__pycache__`, `.pixi`, `.conda`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache` — heavy, regenerable dirs that were deep-copied into every instance. **Data files are still copied** (an instance may need them), per the design intent.
- **#67** — clarify the misleading test comment: `cmd_run` returns 0 because the session lifecycle completed (image built, container ran opencode, cleanup ran); opencode's agent failing for lack of an API key is not a dlab session failure.

Guards: source-level tests that the spinner uses `try/finally` and that the copy exclude list covers the caches but not `data`. Full `test_parallel_tool` + `test_cli` suites pass.

Closes #52. Closes #59. Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)