### PR TITLE
Guard parallel-agents stream readers (#45); search full text (#60)

### DIFF
--- a/dlab/js/parallel-agents.ts
+++ b/dlab/js/parallel-agents.ts
@@ -340,21 +340,32 @@ CRITICAL OUTPUT RULES:
         env: buildInstanceEnv(cwd),  // Curated env (allowlist); never the full host env (#56)
       })
 
-      // Stream to logs (async)
+      // Stream to logs (async). These are fire-and-forget, so a rejected
+      // reader.read() (e.g. the subprocess dies mid-read) would become an
+      // unhandled promise rejection and can crash the whole fan-out under Bun.
+      // Catch it, note it in the log, and stop reading (issue #45).
       ;(async () => {
-        const reader = proc.stdout.getReader()
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          appendFileSync(logFile, new TextDecoder().decode(value))
+        try {
+          const reader = proc.stdout.getReader()
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            appendFileSync(logFile, new TextDecoder().decode(value))
+          }
+        } catch (e) {
+          try { appendFileSync(logFile, `[dlab] stdout stream error: ${e}\n`) } catch {}
         }
       })()
       ;(async () => {
-        const reader = proc.stderr.getReader()
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          appendFileSync(logFile, "[STDERR] " + new TextDecoder().decode(value))
+        try {
+          const reader = proc.stderr.getReader()
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            appendFileSync(logFile, "[STDERR] " + new TextDecoder().decode(value))
+          }
+        } catch (e) {
+          try { appendFileSync(logFile, `[dlab] stderr stream error: ${e}\n`) } catch {}
         }
       })()
 
@@ -427,12 +438,17 @@ RULES:
         env: buildInstanceEnv(cwd),  // Curated env (allowlist); never the full host env (#56)
       })
 
-      // Stream stdout to log file (don't use as summary - it's JSON logs)
-      const reader = consProc.stdout.getReader()
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        appendFileSync(consLogFile, new TextDecoder().decode(value))
+      // Stream stdout to log file (don't use as summary - it's JSON logs).
+      // Guard the read loop so a stream error doesn't abort the tool (#45).
+      try {
+        const reader = consProc.stdout.getReader()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          appendFileSync(consLogFile, new TextDecoder().decode(value))
+        }
+      } catch (e) {
+        try { appendFileSync(consLogFile, `[dlab] stdout stream error: ${e}\n`) } catch {}
       }
       await consProc.exited
 

--- a/dlab/tui/widgets/log_view.py
+++ b/dlab/tui/widgets/log_view.py
@@ -536,7 +536,10 @@ class LogView(VerticalScroll, can_focus=True):
 
         query_lower = query.lower()
         for i, event in enumerate(self._events):
-            if query_lower in event.description.lower():
+            # Match the full untruncated text, so a term that only appears in
+            # the part trimmed for display (a long prompt, an error's response
+            # body) is still found (issue #60).
+            if query_lower in event.full_description.lower():
                 matches.append(i)
 
         return matches

--- a/tests/test_log_view_search.py
+++ b/tests/test_log_view_search.py
@@ -1,0 +1,35 @@
+"""Search matches the full untruncated event text, not just the display
+description (issue #60)."""
+
+from dlab.tui.models import LogEvent
+from dlab.tui.widgets.log_view import LogView
+
+
+def _dlab_start_with_prompt(prompt: str) -> LogEvent:
+    return LogEvent.from_raw(
+        {"type": "dlab_start", "timestamp": 1, "model": "m/x",
+         "agent": "main", "prompt": prompt},
+        source="main",
+    )
+
+
+def test_full_description_holds_prompt_but_short_description_does_not() -> None:
+    ev = _dlab_start_with_prompt("analyze the ZEBRA revenue dataset")
+    assert "ZEBRA" not in ev.description       # trimmed for display
+    assert "ZEBRA" in ev.full_description       # available in full text
+
+
+def test_search_finds_term_only_in_full_description() -> None:
+    lv = LogView()
+    lv._events = [
+        _dlab_start_with_prompt("analyze the ZEBRA revenue dataset"),
+        _dlab_start_with_prompt("nothing relevant here"),
+    ]
+    matches = lv.highlight_search("zebra")
+    assert matches == [0]
+
+
+def test_search_no_match_returns_empty() -> None:
+    lv = LogView()
+    lv._events = [_dlab_start_with_prompt("plain prompt")]
+    assert lv.highlight_search("giraffe") == []

--- a/tests/test_parallel_tool.py
+++ b/tests/test_parallel_tool.py
@@ -182,3 +182,16 @@ class TestYamlImportRuntime:
         assert 'require("yaml")' in PARALLEL_AGENTS_SOURCE, (
             "parallel-agents.ts must use require('yaml') for CJS/ESM compatibility"
         )
+
+
+class TestStreamReaderErrorHandling:
+    """Stream reader loops must catch errors so a dead subprocess mid-read
+    can't become an unhandled rejection that aborts the fan-out (issue #45)."""
+
+    def test_reader_loops_are_guarded(self) -> None:
+        # All three read loops (instance stdout/stderr, consolidator stdout)
+        # log a stream error from a catch block.
+        assert PARALLEL_AGENTS_SOURCE.count("getReader()") == 3
+        assert PARALLEL_AGENTS_SOURCE.count("stream error: ${e}") == 3
+        # and each getReader loop is preceded by a `try {`
+        assert PARALLEL_AGENTS_SOURCE.count("} catch (e) {") >= 3


### PR DESCRIPTION
- **#45** — the instance stdout/stderr reader loops in `parallel-agents.ts` were fire-and-forget async IIFEs with no error handling. A rejected `reader.read()` (the subprocess dying mid-read) became an **unhandled promise rejection** that can crash the whole `parallel-agents` tool call — one instance's stream hiccup taking down the fan-out. All three read loops (instance stdout, instance stderr, consolidator stdout) are now wrapped in `try/catch` that notes the error in the log and stops reading.
- **#60** — log-view search matched only `event.description` (truncated for display), so a term that appears only in the trimmed-away part — deep in a long prompt, or an error's `responseBody` — was never found. Now matches `event.full_description`.

## Tests

`test_log_view_search.py`: a term in the prompt (present in `full_description`, absent from the short `description`) is found by `highlight_search`. `test_parallel_tool.py`: source guard that all three reader loops log a stream error from a `catch` block.

Closes #45. Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)