### PR TITLE
Fix Gantt running bar (#64) and wizard task-permission footgun (#47)

### DIFF
--- a/dlab/create_dpack.py
+++ b/dlab/create_dpack.py
@@ -169,7 +169,7 @@ NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 # default_value is "allow" or "deny".
 # Ordered by importance — high-impact first, internal/basic last.
 # The wizard renders a visual separator at HIGH_IMPACT_PERMISSION_COUNT.
-HIGH_IMPACT_PERMISSION_COUNT: int = 6
+HIGH_IMPACT_PERMISSION_COUNT: int = 5
 
 CONFIGURABLE_PERMISSIONS: list[tuple[str, str, str, str]] = [
     # --- High-impact (affect agent capabilities) ---
@@ -191,9 +191,8 @@ CONFIGURABLE_PERMISSIONS: list[tuple[str, str, str, str]] = [
      "Read files outside /workspace (e.g. Python site-packages, system configs). "
      "Useful for exploring installed libraries programmatically.",
      "allow"),
-    ("task", "Spawn subagent tasks",
-     "Let the agent spawn subagent tasks. Required for multi-agent workflows.",
-     "allow"),
+    # NB: `task` is intentionally NOT here — it is hardcoded to allow, because
+    # denying it silently breaks parallel-agents/subagent workflows (issue #47).
     # --- Internal/basic (rarely need to change) ---
     ("skill", "Use skills",
      "Let the agent use opencode skills (knowledge files). "
@@ -220,6 +219,10 @@ HARDCODED_PERMISSIONS: dict[str, str] = {
     "glob": "allow",
     "grep": "allow",
     "list": "allow",
+    # Always allowed, not user-configurable: an orchestrator with parallel
+    # agents / subagents needs `task`, and denying it silently breaks the
+    # parallel-agents workflow. Harmless when unused (issue #47).
+    "task": "allow",
     "question": "deny",   # meaningless in automated mode
     # TODO: decide on doom_loop default. OpenCode defaults to "ask" (auto-approved
     # in run mode). Setting "deny" would stop agents stuck in loops but might block

--- a/dlab/timeline.py
+++ b/dlab/timeline.py
@@ -555,9 +555,9 @@ def print_timeline(timeline: dict[str, Any]) -> None:
             for i in range(max(idle_start_pos, start_pos), min(idle_end_pos + 1, end_pos, width)):
                 bar_chars[i] = "░"
 
-        # If source is still running, use different end character
-        if source_running and end_pos > 0 and end_pos <= width:
-            bar_chars[end_pos - 1] = "░"
+        # A running source is shown active to its end (solid █); the "..."
+        # duration suffix marks it as ongoing. Only real idle periods above are
+        # greyed — don't grey the running tail, which reads as idle (issue #64).
 
         bar = "".join(bar_chars)
         duration = format_duration(summary["duration_ms"])

--- a/tests/test_create_dpack.py
+++ b/tests/test_create_dpack.py
@@ -296,6 +296,25 @@ class TestPermissions:
         # question is hardcoded to deny, not configurable
         assert data["permission"]["question"] == "deny"
 
+    def test_task_is_always_allowed_and_not_configurable(self, tmp_path: Path) -> None:
+        """Issue #47: `task` must be hardcoded to allow — a user cannot deny it
+        (which would silently break parallel-agents/subagent workflows)."""
+        from dlab.create_dpack import CONFIGURABLE_PERMISSIONS
+
+        assert "task" not in {p[0] for p in CONFIGURABLE_PERMISSIONS}
+
+        config: dict[str, Any] = {
+            "name": "perm-task",
+            # Even if a caller tries to deny task, it must stay allowed.
+            "permissions": {"task": "deny"},
+            "skeletons": {"parallel_agents": True},
+        }
+        generate_dpack(tmp_path, config)
+        data: dict[str, Any] = json.loads(
+            (tmp_path / "perm-task" / "opencode" / "opencode.json").read_text()
+        )
+        assert data["permission"]["task"] == "allow"
+
 
 class TestSkeletonSubagents:
     """Tests for subagents skeleton (without parallel)."""


### PR DESCRIPTION
- **#64** (Minor) — the Gantt forced a running source's last bar char to the grey idle glyph `░`, so an actively-running agent's bar read as idle. Removed; running bars stay solid `█` and the `...` duration suffix already signals "ongoing". Only genuine idle periods are greyed.
- **#47** (Serious) — `task` was a wizard checkbox. Unchecking it wrote `task: deny`, which silently breaks the orchestrator's parallel-agents/subagent workflow. Moved `task` from `CONFIGURABLE_PERMISSIONS` to `HARDCODED_PERMISSIONS` (always allow — harmless when unused), and dropped `HIGH_IMPACT_PERMISSION_COUNT` 6→5 so the wizard's separator stays correct.

## Tests

New (#47): `task` is not in `CONFIGURABLE_PERMISSIONS`, and a generated pack has `task: allow` even when the caller passes `permissions={"task": "deny"}`. create_dpack + wizard suites pass (103). No test for #64 — a Minor rendering deletion in a print-heavy function.

Closes #64. Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)