### PR TITLE
Session digest + `dlab digest` + provenance-first redesign (#85)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,6 +86,9 @@ dlab timeline [work-dir]
 
 # Browser-based session viewer (DAG visualization)
 dlab view <work-dir> [--port PORT] [--no-open] [--export FILE]
+
+# Print (or write) a deterministic session digest
+dlab digest [work-dir] [--brief] [--write]
 ```
 
 ## Coding Style
@@ -143,6 +146,8 @@ dlab view <work-dir> [--port PORT] [--no-open] [--export FILE]
 - `local.py` - Local (no-Docker) execution backend for `--no-sandboxing`
 - `model_fallback.py` - Model validation and provider fallback (`preflight_check` before session creation, `process_opencode_dir` during setup) so a single API key suffices
 - `opencode_logparser.py` - Canonical OpenCode NDJSON log parser (`LogEvent`, `SessionNode`, `parse_log_file`, `build_session_graph`); single source of truth used by `timeline.py`, `tui/`, and `viewer/`
+- `session_digest.py` - Deterministic session digest for the notebook composer (`build_digest`, `generate_digest`); builds `_digest/digest.md` + `_digest/index.json` on top of `opencode_logparser`. Surfaced by the `dlab digest` subcommand.
+- `js/digest-get.ts` - In-container retrieval tool (loaded as `DIGEST_GET_SOURCE`) that reads one indexed NDJSON line by ID and renders it decoded/sliced
 - `parallel_tool.py` - Loads parallel-agents.ts from `js/`
 - `js/parallel-agents.ts` - TypeScript source bundled as package data
 - `data/models.json` - Bundled models.dev model list (package data)

--- a/.claude/specs/notebook-composer.md
+++ b/.claude/specs/notebook-composer.md
@@ -455,7 +455,12 @@ Changed files:
 2. Level C: `dlab notebooks --execute` with `long-running` skipping.
 3. Per-dpack composer hints / output-dir config.
 4. Derived-stats layer refactor (timeline + viewer + digest sharing rollups).
-5. Promoting `dlab digest` to a documented subcommand.
+5. ~~Promoting `dlab digest` to a documented subcommand.~~ **Done** (Ben pulled
+   this forward and shipped it with #85): `dlab digest [WORK_DIR] [--brief]
+   [--write]` prints the digest to stdout, or with `--write` materializes the
+   `_digest/` pair. The digest remains internal plumbing for the composer step;
+   this is only a read/inspect surface over the same `build_digest`/
+   `generate_digest` functions.
 
 ## 12. Open implementation checks (the only genuinely open points)
 

--- a/.claude/specs/notebook-composer.md
+++ b/.claude/specs/notebook-composer.md
@@ -143,6 +143,16 @@ tackle level C at a later stage."*
   order, imports present, paths relative to the workdir, code taken **verbatim
   from scripts that actually ran**, with a provenance comment per code cell:
   `# from parallel/run-1784.../instance-2/fit_model.py`.
+  - **Tool-generated outputs (correction, 2026-07-31):** "verbatim from scripts
+    that ran" silently assumed *agent-written* scripts. Many outputs (figures,
+    result files) are produced by a **custom tool** whose code lives in its
+    `.opencode/tools/<name>.ts` (which shells out to a library CLI), not in any
+    logged script. A figure embedded under a bare comment is not runnable. The
+    runnable representation is the **tool's own invocation**, reproduced from the
+    tool source the digest now surfaces (§7.2), at the deepest affordable level
+    (granular library call → top-level function → shell-out; §8). One tool call
+    = one regeneration cell (which produces all its outputs) + runnable
+    `Image(...)` display cells. Any such reconstruction is disclosed via `nb-note`.
 - **Level C — verified re-executable (deferred)**: `dlab notebooks --execute`,
   opt-in, runs in the container, skips cells tagged `long-running`.
 
@@ -208,8 +218,14 @@ lines of Bun). Tool surface (~5 tools, deliberately small):
 | `nb-add-markdown-cell` | `notebook, text, math?` | Appends markdown cell. Escapes `$` → `\$` by default (auto-mined text is almost always currency); `math: true` per cell opts into MathJax. |
 | `nb-add-code-cell` | `notebook, code, outputs?, tags?` | Appends code cell. `outputs` is a list of `{image: <path>}` \| `{stream: <text>}`; the TOOL reads the figure file and base64-encodes it into a proper `display_data`/`stream` output — the model only ever passes paths. Assigns sequential `execution_count`. `tags` for `long-running`. |
 | `nb-edit-cell` | `notebook, index, …` | Replace source/outputs of an existing cell (for fixes). |
+| `nb-note` | `notebook, text, math?` | Appends to the notebook's **first cell — the markdown "preamble"** (index-independent; creates it if the top isn't markdown). The composer's **disclosure** surface: whatever it reconstructed rather than took verbatim (regenerated figures, code reproduced at a coarser level, results trusted from a summary, inherited data). |
 | `nb-read` | `notebook` | **Compact rendering, base64 stripped**: `cell 7 [code, exec 7, 1 image output: figures/adstock.png]` + truncated sources. Agents must never read raw ipynb (base64 in context = the same poison we keep out of writing). |
-| `nb-finalize` | `notebook` | Injects the provenance header cell (idempotent), final consistency pass, writes canonical JSON. |
+| `nb-finalize` | `notebook` | Pins the provenance header to the top of the preamble cell (idempotent; provenance + notes stay ONE markdown cell), final consistency pass, writes canonical JSON. |
+
+**Invariant — the first cell is always the markdown preamble** (provenance line
++ any `nb-note` disclosures). Implemented (#86, PR #89): the six `.ts` tools are
+flat in `dlab/js/` (`nb-add-markdown-cell`, `nb-add-code-cell`, `nb-edit-cell`,
+`nb-note`, `nb-read`, `nb-finalize`).
 
 **Research record (2026-07-29)** — checked before deciding to build:
 
@@ -422,10 +438,25 @@ host-side Python indexer):
   `range` (line-based slicing of the payload).
 - Behavior: look up ID in `_digest/index.json` → read the referenced NDJSON
   line(s), `line_no..line_end` → render the payload for the event type:
-  `t`-ids → tool input + structured output **plus the mapped raw_text block**;
+  `t`-ids → tool input + structured output **plus the mapped raw_text block**,
+  and **for a custom tool the code the tool ran** (its `.opencode/tools/<name>.ts`
+  source, appended under `# the code this tool ran`) — so one retrieval gives
+  "the call was XXX and the code it ran was YYY";
   `r`-ids → the raw_text block verbatim; `x`-ids → the verbatim text;
   `a`-ids → the small text artifact's contents — all **decoded** (clean
   stdout/stderr, not escaped JSON) → slice.
+
+**Custom-tool provenance (general, no per-dpack knowledge)**: a tool call is
+*custom* iff a `.opencode/tools/<name>.ts` exists in the workdir (built-in
+`bash`/`read`/`write`/`edit` have none — their "code" is already the command or
+file content). Custom calls are flagged `(custom)` in the Tool-calls row, their
+`tN` index entry carries a `tool_source` pointer, and `digest-get` bundles that
+source into the retrieval. This is what lets the composer make tool-generated
+outputs runnable: it reads the source (e.g. that `analyze-model` runs
+`python -m mmm_lib.analyze_model_cli …`) and reproduces the invocation at the
+deepest affordable level (§5), instead of embedding an orphaned figure. Works
+for any pack's tools — the digest surfaces whatever `.ts` is there; the model
+interprets it.
 - Why slicing is required: a PyMC fit's raw_text can be thousands of lines; the
   composer grabs `digest-get poet.r2.i2/r11 --tail 15` for a traceback without
   paying for sampler progress. (It is also how the composer pulls a cell's
@@ -480,13 +511,22 @@ composer's analytical job, and in the experiment it did.
 
 ## 8. Composer agent environment
 
-- The composer is **dlab-internal**: its agent prompt is a template shipped as
-  dlab package data (like `js/parallel-agents.ts`), NOT part of any dpack.
-  Placeholder rules from CLAUDE.md apply (no hard-coded values; `<VALUE>`
-  placeholders).
+- The composer is **dlab-internal**: its system prompt is a versioned file,
+  **`dlab/agents/composer.md`** (implemented, PR #89; registered as `dlab.agents`
+  package data), NOT part of any dpack. It is **fully dpack-agnostic** — a test
+  asserts no library/pack specifics leak in (`mmm_lib`/`pymc`/…). Its frontmatter
+  wires the tools (`digest-get` + the six `nb-*`) and denies `edit`/`bash`/`task`.
+- **The composer's core rules (all in `composer.md`)**: composed-not-executed +
+  provenance; digest + `digest-get` as the *only* log interface; fit-then-load
+  runnability; the **general 3→2→1 reproduction of custom-tool-generated
+  outputs** (read the tool's source from its `tN` retrieval, then reproduce at
+  the deepest affordable level — granular library call per figure → top-level
+  function → reproduce the invocation; never inline library internals, never a
+  figure under a bare comment); and the **`nb-note` disclosure rule** — every
+  reconstruction is disclosed in the first-cell preamble.
 - dlab materializes the composer environment into the workdir at composer-launch
-  time (analogous to `setupConsolidator`): composer agent `.md`, the five `nb-*`
-  tools, `digest-get`, and permission config.
+  time (analogous to `setupConsolidator`): `composer.md`, the six `nb-*` tools,
+  `digest-get`, and permission config.
 - **Permissions** (lesson from PR #38 encoded here): the composer does NOT need
   the `edit` permission — all its file writes go through the custom `nb-*`
   tools, which are not gated by the `edit` permission key. So: `read`/`glob`/

--- a/.claude/specs/notebook-composer.md
+++ b/.claude/specs/notebook-composer.md
@@ -247,22 +247,50 @@ Outputs written into the workdir:
 
 - `_digest/digest.md` — the LLM-facing map (format below).
 - `_digest/index.json` — machine index: every ID → `{log_file, line_no,
-  event_type}`. **Thin index** (pointers, not payloads): a fat index storing
-  extracted payloads would duplicate log content on disk.
+  line_end?, event_type}`. **Thin index** (pointers, not payloads): a fat index
+  storing extracted payloads would duplicate log content on disk. `line_end` is
+  present for multi-line payloads — a `raw_text` block, or a `tool_use` whose
+  mapped raw_text stream extends past its own line.
 
 ### 7.1 Digest format
+
+> **Revised 2026-07-30** after reviewing the digest against a real completed mmm
+> run (`dlab-mmm-agent-oc-workdir-008`). Changes, all validated on that run:
+> artifacts are **provenance-first** (every file links to the tool call that
+> produced/copied it; inherited untouched copies dropped by sha256; the parent's
+> `cp`'d files stay, linked to the copy); **all producing tool calls are
+> labeled** (not just bash), so every referenced ID is a visible row; and
+> **`raw_text` (the majority of a real log — the tracebacks and sampler output)
+> is a first-class `r`-id**, mapped to its tool call and retrievable, because it
+> is what the composer embeds as a cell's `stream` output. The `dlab digest`
+> command (spec §11.5) and the produced/inherited attribution already shipped in
+> PR #87; the tool-call-labeling + `raw_text` mapping are the remaining build.
 
 Header: dpack name, models, total duration, total cost. Workflow tree. Then
 **one `###` section per agent (orchestrator AND every instance AND
 consolidators), identical structure** (Ben's requirement).
 
 **ID scheme — one shared event counter per agent; the numbering IS the
-timeline** (this resolved Ben's chronology concern; it is load-bearing):
-`t07` (tool call), `x08` (text/reasoning), `t09` — kind-prefix says *what*,
-the shared number says *when*. Artifact IDs (`a1`, `a2`, …) are per-agent and
-not on the event counter (artifacts are files, not events); their provenance
-is expressed through event IDs. Fully-qualified form for retrieval:
-`<agent-path>/<id>`, e.g. `main/t17`, `poet.r2.i2/t4`.
+timeline** (load-bearing, resolved Ben's chronology concern): `t07` (tool
+call), `x08` (text/reasoning), `r09` (raw_text stream) — the kind-prefix says
+*what*, the shared number says *when*. Every event is addressable.
+
+`raw_text` is the plain stdout/stderr the opencode process emits **outside** the
+structured tool events. On a real mmm instance it is the *majority* of the log
+(e.g. 166 of 266 lines) and holds the material that matters most — the
+Modal/PyMC tracebacks, sampler diagnostics, "saved to fitted_model.nc" lines.
+It carries **no timestamp**, so it is ordered by line position and a run of
+consecutive raw_text is associated with the **most recent `tool_use` before it**
+(positional; the parser already groups the run into one block). Each block gets
+one `r`-id on the shared counter and is **mapped to its tool call**. This is the
+material the composer embeds as a cell's `stream` output (§5). Remote Modal-side
+fit logs are **not** fetched (out of scope) — only what the local session log
+captured.
+
+Artifact IDs (`a1`, `a2`, …) and the Task ID (`p0`) are per-agent and off the
+event counter (files/prompts are not events); their provenance is expressed
+through event IDs. Fully-qualified form for retrieval: `<agent-path>/<id>`,
+e.g. `main/t17`, `poet.r2.i2/r4`.
 
 **Task field** (per agent section, required): the *differentiating* portion of
 the agent's prompt — for parallel instances, the orchestrator-supplied prompt
@@ -272,13 +300,28 @@ full prompt retrievable via `digest-get <agent>/p0`. Rationale: the composer
 cannot narrate alternatives ("instance 2 tried geometric adstock, instance 3
 Weibull") without knowing what each instance was asked to do.
 
-**Artifact write chains**: every artifact lists its full write history in
-order — `[a5] summary.md (written t12, overwritten t31)` — content attributed
-to the **last** writer, earlier writers kept visible so the composer knows a
-retry replaced it. Derived deterministically from write/edit tool inputs.
-Cross-agent overwrites (e.g. orchestrator regenerating `report.md`) appear the
-same way in the main-agent section; instance workdirs are isolated and cannot
-clobber each other.
+**Artifact provenance (produced vs. inherited)** — every artifact links to the
+tool call in *this agent* that produced or copied it:
+
+- `write`/`edit` → chain by `filePath`: `written t6, edited t9` (full write
+  history in order; content attributed to the last writer, earlier writers kept
+  visible so the composer sees a retry replaced it).
+- `bash` / custom tool (`fit-model-modal`, `analyze-model`) / `cp` → matched by
+  **mtime ∈ [call.start, call.end]** — the file was written during that call's
+  window: `← from t10 (bash: python fit_model.py)`, `← from t16
+  (fit-model-modal)`. mtime is safe here because it is used **only on files
+  already proven produced**, never to detect copies (Ben's tier-3, applied
+  where it cannot misfire).
+
+The **parent's `cp`'d artifacts stay visible**, linked to the copy call —
+`best_model.nc ← from t52 (cp)` — because the copy IS a producing call.
+
+A file is **dropped** only when it has **no producing call in this agent** *and*
+is byte-identical (sha256) to the workspace-root seed — i.e. it arrived via the
+invisible `copyWorkDir` fan-out and was never touched. Chronology +
+sibling-isolation gate this so a creator never loses its own file to a later
+`cp`, and isolated siblings never shadow each other. A seeded file the agent
+then *edited* is kept — it has an edit call.
 
 **Header + workflow-tree format** (schematic):
 
@@ -310,36 +353,44 @@ model: anthropic/claude-sonnet-4-5 | 214s | $0.31 | 19 tool calls
 workdir: parallel/run-1784571692537/instance-2/
 
 **Task** [p0]: "Fit a geometric-adstock MMM with saturating priors on /workspace/data;
-run seeds [0,1,2] and report median F1…" (differentiating portion of the instance
-prompt; full prompt via digest-get poet.r2.i2/p0)
+run seeds [0,1,2] and report median F1…" (differentiating portion; full prompt
+via digest-get poet.r2.i2/p0)
 
-**Artifacts** (7)
-- [a1] fit_model.py            (4.1KB, written t6, edited t9)
-- [a2] idata.nc                (2.3MB, from t10)
-- [a3] figures/adstock_curves.png   (142KB)
-- [a4] figures/posterior_roas.png   (98KB)
-- [a5] summary.md              (1.8KB)   ← instance conclusion
-- [a6] analysis_output/analysis_summary.json (0.9KB)
+**Artifacts** (6 produced)
+- [a1] fit_model.py            (4.1KB)  ← written t6, edited t9
+- [a2] idata.nc               (2.3MB)  ← from t10 (bash: python fit_model.py)
+- [a3] figures/adstock_curves.png (142KB) ← from t14 (bash: python make_figures.py)
+- [a4] figures/posterior_roas.png (98KB)  ← from t14
+- [a5] summary.md             (1.8KB)  ← written t16   (instance conclusion)
+- [a6] analysis_output/analysis_summary.json (0.9KB) ← from t12 (analyze-model)
+(cleaned_data.parquet, data_summary.md — inherited, untouched → hidden)
 
-**Script runs**
-- [t7]  bash `python fit_model.py`         ✗ error   (stderr 41 lines — KeyError: 'is_valid')
-- [t10] bash `python fit_model.py`         ✓ 312s    (stdout 6,204 lines — sampler progress + diagnostics)
-- [t14] bash `python make_figures.py`      ✓ 8s      (stdout 12 lines)
-
-**Other tool calls**: read×4, edit×2, write×3
+**Tool calls**  (producing calls, each addressable; raw_text stream mapped in)
+- [t6]  write fit_model.py
+- [t7]  bash  `python fit_model.py`     ✗ error  0s   → r8  (stderr 41 ln — KeyError: 'is_valid')
+- [t9]  edit  fit_model.py              (fix)
+- [t10] bash  `python fit_model.py`     ✓ 312s        → r11 (stdout 6,204 ln — sampler + diagnostics)
+- [t12] analyze-model                   ✓             → analysis_output/
+- [t14] bash  `python make_figures.py`  ✓ 8s          → r15 (stdout 12 ln)
+- [t16] write summary.md
+**Navigational**: read×4, todowrite×3, glob×1
 **Reasoning excerpts**
-- [x8] "The first fit failed on the validation key; fixing and rerunning…"
-- [x16] "r̂ ≤ 1.01 on all parameters, 0 divergences — this configuration converged. Writing summary…"
+- [x8]  "The first fit failed on the validation key; fixing and rerunning…"
+- [x18] "r̂ ≤ 1.01 on all parameters, 0 divergences — converged. Writing summary…"
 ```
 
-(Note the shared counter: `t7 → x8 → t9(edit) → t10` reads as the story arc
-"failed → reasoned → fixed → succeeded" directly off the numbers.)
+(The shared counter runs `t6 → t7 → r8 → x… → t9 → t10 → r11 …`: "wrote → ran →
+it errored (r8) → reasoned → fixed → ran → it worked (r11)" reads straight off
+the numbering — raw_text now included as a first-class element. Every `← from
+tN` and every `→ rN` points at a labeled row, so no ID is referenced without
+being shown.)
 
 **`--brief` variant** (agreed): keeps per-agent header stats, Artifacts with
-write chains, Script runs with ✓/✗, Reasoning excerpts; collapses the tool
-tables to the one-line counts. The index is unaffected — brief trims the map,
-not addressability. Expected size: full digest for a big mmm run ≈ 500–1500
-dense lines (acceptable: it is the map, ~100× smaller than the logs).
+their provenance links, and the ✓/✗ + raw_text-tail for producing calls;
+collapses the full Tool-calls table and Reasoning to one-line counts/first
+lines. The index is unaffected — brief trims the *map*, not addressability.
+Expected size: full digest for a big mmm run ≈ 500–1500 dense lines (acceptable:
+it is the map, ~100× smaller than the logs).
 
 ### 7.2 Retrieval: the `digest-get` tool
 
@@ -356,15 +407,17 @@ output embedded as an escaped string; reading it hands the composer a wall of
 lines of stdlib TS, no parser port, no drift; intelligence stays in the
 host-side Python indexer):
 
-- Args: `id` (fully qualified, e.g. `poet.r2.i2/t7`), optional `head`, `tail`,
+- Args: `id` (fully qualified, e.g. `poet.r2.i2/r8`), optional `head`, `tail`,
   `range` (line-based slicing of the payload).
-- Behavior: look up ID in `_digest/index.json` → read that single NDJSON line →
-  `JSON.parse` → extract the payload field for the event type (tool input +
-  output for `t`-ids, verbatim text for `x`-ids) → render **decoded** (clean
-  stdout/stderr, not escaped JSON) → slice.
-- Why slicing is required: a PyMC fit log can be thousands of lines; the
-  composer grabs `digest-get poet.r2.i2/t7 --tail 15` for a traceback without
-  paying for sampler progress.
+- Behavior: look up ID in `_digest/index.json` → read the referenced NDJSON
+  line(s), `line_no..line_end` → render the payload for the event type:
+  `t`-ids → tool input + structured output **plus the mapped raw_text block**;
+  `r`-ids → the raw_text block verbatim; `x`-ids → the verbatim text — all
+  **decoded** (clean stdout/stderr, not escaped JSON) → slice.
+- Why slicing is required: a PyMC fit's raw_text can be thousands of lines; the
+  composer grabs `digest-get poet.r2.i2/r11 --tail 15` for a traceback without
+  paying for sampler progress. (It is also how the composer pulls a cell's
+  `stream` output — full or tail — to embed in the notebook, §5.)
 
 **Text/reasoning events are first-class retrievable elements** (`x`-ids) — the
 digest excerpts them truncated; the composer pulls full verbatim text by ID.

--- a/.claude/specs/notebook-composer.md
+++ b/.claude/specs/notebook-composer.md
@@ -250,7 +250,9 @@ Outputs written into the workdir:
   line_end?, event_type}`. **Thin index** (pointers, not payloads): a fat index
   storing extracted payloads would duplicate log content on disk. `line_end` is
   present for multi-line payloads — a `raw_text` block, or a `tool_use` whose
-  mapped raw_text stream extends past its own line.
+  mapped raw_text stream extends past its own line. For a small text artifact
+  (`event_type: "artifact"`), `log_file` points at the artifact file itself and
+  `digest-get` returns its contents — still a pointer, not a stored payload.
 
 ### 7.1 Digest format
 
@@ -289,8 +291,17 @@ captured.
 
 Artifact IDs (`a1`, `a2`, …) and the Task ID (`p0`) are per-agent and off the
 event counter (files/prompts are not events); their provenance is expressed
-through event IDs. Fully-qualified form for retrieval: `<agent-path>/<id>`,
-e.g. `main/t17`, `poet.r2.i2/r4`.
+through event IDs. **Small text artifacts (`.json/.csv/.md/.txt/.yaml` under
+32KB) are retrievable** — `digest-get <agent>/a5` returns the file's contents,
+sliced — and the digest shows a deterministic **shape hint** next to each so the
+composer decides *whether* and *which slice* to pull before spending context:
+JSON → top-level keys, CSV → header columns + row count, text → line count +
+first heading. Big/binary artifacts (`.nc`, `.png`, `.pkl`) stay pure pointers
+(size only, not retrievable). This closes a gap found in the composer experiment
+(§7.4): the per-instance result files — each non-adopted modeler's
+`analysis_summary.json`/`roas.csv` — were otherwise unreadable, forcing the
+composer to trust the orchestrator's transcription. Fully-qualified retrieval
+form: `<agent-path>/<id>`, e.g. `main/t17`, `poet.r2.i2/r4`, `poet.r2.i2/a5`.
 
 **Task field** (per agent section, required): the *differentiating* portion of
 the agent's prompt — for parallel instances, the orchestrator-supplied prompt
@@ -412,8 +423,9 @@ host-side Python indexer):
 - Behavior: look up ID in `_digest/index.json` → read the referenced NDJSON
   line(s), `line_no..line_end` → render the payload for the event type:
   `t`-ids → tool input + structured output **plus the mapped raw_text block**;
-  `r`-ids → the raw_text block verbatim; `x`-ids → the verbatim text — all
-  **decoded** (clean stdout/stderr, not escaped JSON) → slice.
+  `r`-ids → the raw_text block verbatim; `x`-ids → the verbatim text;
+  `a`-ids → the small text artifact's contents — all **decoded** (clean
+  stdout/stderr, not escaped JSON) → slice.
 - Why slicing is required: a PyMC fit's raw_text can be thousands of lines; the
   composer grabs `digest-get poet.r2.i2/r11 --tail 15` for a traceback without
   paying for sampler progress. (It is also how the composer pulls a cell's
@@ -436,6 +448,35 @@ run-grouping-by-agent-name, artifact discovery), currently duplicated in
 timeline.py and session_data.py and now needed a third time. Plan: digest ships
 first computing its own stats; lifting shared helpers into the parser layer is
 an **incremental, non-blocking** follow-up (§11.4).
+
+### 7.4 Validation: the composer experiment (2026-07-31)
+
+Before building the composer step, an LLM agent was given the digest of a real
+completed run (`dlab-mmm-agent-oc-workdir-008`, 8 agents) plus `digest-get`, and
+asked to compose the overview + adopted-path notebooks **from the digest alone —
+forbidden from reading raw logs**. It succeeded: it identified the adopted model
+(via the `cp`-provenance on `best_model.nc` + a size match), narrated the failed
+instance and the retry/fix arcs, and inlined the adopted path in fit-then-load
+order. So the format is LLM-legible. Its critique drove concrete digest fixes,
+all now shipped:
+
+- **Custom-tool input signatures** — `fit-model-modal`/`analyze-model`/
+  `optimize-budget` rows show `{key=value, …}` (the reproducible call args),
+  paths keeping their filename end. Previously invisible until retrieved.
+- **Error-preview tails keep the line's END** (the exception / offending key),
+  not the head.
+- **A consolidator that wrote no `consolidated_summary.md` is flagged failed**,
+  like a summary-less modeler.
+- **LSP/type-checker diagnostics are stripped** from tool output in both the
+  digest and `digest-get`.
+- **Small text artifacts became retrievable with shape hints** (this §7.1 point)
+  — the single highest-value gap it named.
+
+One finding was *not* a digest bug and was filed against the mmm dpack (issue
+#88): the orchestrator proposed a degenerate modeling plan ("channel-specific
+adstock" is PyMC-Marketing's default, so it duplicated the baseline). The digest
+surfaced the raw material correctly; recognizing the equivalence is the
+composer's analytical job, and in the experiment it did.
 
 ## 8. Composer agent environment
 

--- a/dlab/cli.py
+++ b/dlab/cli.py
@@ -1174,6 +1174,97 @@ def cmd_timeline(work_dir: str | None = None) -> int:
     return run_timeline(work_dir_path)
 
 
+@app.command("digest")
+def _cmd_digest(
+    work_dir: Annotated[
+        str | None,
+        typer.Argument(
+            metavar="WORK_DIR",
+            help="Path to session work directory "
+            "(default: cwd if it contains _opencode_logs)",
+        ),
+    ] = None,
+    brief: Annotated[
+        bool,
+        typer.Option(
+            "--brief",
+            help="Collapse per-agent tool tables to one-line counts",
+        ),
+    ] = False,
+    write: Annotated[
+        bool,
+        typer.Option(
+            "--write",
+            "-w",
+            help="Write _digest/digest.md and _digest/index.json into the "
+            "work dir instead of printing the digest to stdout",
+        ),
+    ] = False,
+) -> None:
+    """Build a deterministic session digest (the composer's LLM-facing map)."""
+    exit_code = cmd_digest(work_dir=work_dir, brief=brief, write=write)
+    raise typer.Exit(code=exit_code)
+
+
+def cmd_digest(
+    work_dir: str | None = None, brief: bool = False, write: bool = False
+) -> int:
+    """
+    Handle digest mode - build a deterministic session digest from a work dir.
+
+    Prints the digest markdown to stdout by default; with ``write`` set,
+    materializes ``_digest/digest.md`` and ``_digest/index.json`` into the work
+    directory (the same pair the composer step consumes).
+
+    Parameters
+    ----------
+    work_dir : str | None
+        Session work directory. If None, uses the current directory when it
+        contains an ``_opencode_logs`` folder.
+    brief : bool
+        Collapse the per-agent tool tables to one-line counts.
+    write : bool
+        Write the digest files into the work dir instead of printing.
+
+    Returns
+    -------
+    int
+        Exit code (0 for success, non-zero for failure).
+    """
+    from dlab.session_digest import build_digest, generate_digest
+
+    if work_dir:
+        work_dir_path: Path = Path(work_dir).resolve()
+    else:
+        cwd: Path = Path.cwd()
+        if (cwd / "_opencode_logs").is_dir():
+            work_dir_path = cwd
+        else:
+            print(
+                "Error: No work directory specified and no _opencode_logs in "
+                "current directory",
+                file=sys.stderr,
+            )
+            return 1
+
+    if not (work_dir_path / "_opencode_logs").is_dir():
+        print(
+            f"Error: No _opencode_logs directory found in {work_dir_path}",
+            file=sys.stderr,
+        )
+        print("Make sure this is a valid dlab session directory.", file=sys.stderr)
+        return 1
+
+    if write:
+        out_dir: Path = generate_digest(work_dir_path, brief=brief)
+        print(f"Wrote {out_dir / 'digest.md'}")
+        print(f"Wrote {out_dir / 'index.json'}")
+    else:
+        markdown, _index = build_digest(work_dir_path, brief=brief)
+        sys.stdout.write(markdown)
+    return 0
+
+
 @app.command("create-dpack")
 def _cmd_create_dpack(
     output_dir: Annotated[

--- a/dlab/js/digest-get.ts
+++ b/dlab/js/digest-get.ts
@@ -5,20 +5,21 @@ const { join } = require("path")
 
 // Deliberately dumb retrieval tool (issue #85): the host-side Python digest
 // owns all the intelligence and writes _digest/index.json mapping every ID to
-// {log_file, line_no, event_type}. This tool just looks up one ID, reads that
-// single NDJSON line, extracts the payload, and renders it DECODED (clean
-// stdout/stderr, not escaped JSON) with optional slicing.
+// {log_file, line_no, line_end?, event_type}. This tool just looks up one ID,
+// reads that line (or line range, for a raw_text block), extracts the payload,
+// and renders it DECODED (clean stdout/stderr, not escaped JSON) with slicing.
 
 export default tool({
   description:
-    "Retrieve a single log element by its digest ID (the [t.]/[x.]/[p0] ids in _digest/digest.md). " +
-    "IDs are fully qualified, e.g. 'main/t2' or 'poet.r1.i2/x8'. Returns the decoded payload: " +
-    "for a tool call, its input plus clean stdout/stderr; for a text/reasoning id, the verbatim text; " +
-    "for p0, the full prompt. Use head/tail/range to slice long output (e.g. a PyMC fit log) " +
-    "instead of paying for all of it.",
+    "Retrieve a single log element by its digest ID (the [tN]/[xN]/[rN]/[p0] ids in _digest/digest.md). " +
+    "IDs are fully qualified, e.g. 'main/t2', 'poet.r1.i2/x8', 'poet.r1.i2/r11'. Returns the decoded payload: " +
+    "for a tool call (tN) its input plus clean stdout/stderr; for a raw_text stream (rN) the verbatim " +
+    "stdout/stderr the run emitted — this is what you embed as a cell's stream output; for a text id (xN) " +
+    "the verbatim reasoning; for p0 the full prompt. Use head/tail/range to slice long output (e.g. a PyMC " +
+    "fit log) instead of paying for all of it.",
 
   args: {
-    id: tool.schema.string().describe("Fully-qualified digest ID, e.g. 'poet.r1.i2/t7'"),
+    id: tool.schema.string().describe("Fully-qualified digest ID, e.g. 'poet.r1.i2/r11'"),
     head: tool.schema.number().optional().describe("Return only the first N lines of the payload"),
     tail: tool.schema.number().optional().describe("Return only the last N lines of the payload"),
     range: tool.schema.string().optional().describe("Return lines A-B of the payload, e.g. '10-40'"),
@@ -26,7 +27,7 @@ export default tool({
 
   async execute({ id, head, tail, range }) {
     const cwd = process.cwd()
-    let index: Record<string, { log_file: string; line_no: number; event_type: string }>
+    let index: Record<string, { log_file: string; line_no: number; line_end?: number; event_type: string }>
     try {
       index = JSON.parse(readFileSync(join(cwd, "_digest", "index.json"), "utf-8"))
     } catch {
@@ -35,14 +36,23 @@ export default tool({
     const entry = index[id]
     if (!entry) return `ERROR: unknown digest id '${id}'`
 
-    let rawLine: string
+    let selected: string[]
     try {
-      const content = readFileSync(join(cwd, entry.log_file), "utf-8")
-      rawLine = content.split("\n")[entry.line_no - 1] ?? ""
+      const content = readFileSync(join(cwd, entry.log_file), "utf-8").split("\n")
+      const end = entry.line_end ?? entry.line_no
+      selected = content.slice(entry.line_no - 1, end) // 1-based inclusive
     } catch {
       return `ERROR: cannot read ${entry.log_file}`
     }
 
+    // raw_text: a block of plain stdout/stderr lines, no JSON. Strip the
+    // [STDERR] markers so it reads as clean output ready to embed.
+    if (entry.event_type === "raw_text") {
+      const text = selected.map((l) => l.replace(/^\[STDERR\]\s?/, "")).join("\n")
+      return sliceText(text, head, tail, range)
+    }
+
+    const rawLine = selected[0] ?? ""
     let obj: any
     try {
       obj = JSON.parse(rawLine)

--- a/dlab/js/digest-get.ts
+++ b/dlab/js/digest-get.ts
@@ -70,10 +70,19 @@ function renderPayload(obj: any, eventType: string): string {
   if (eventType === "tool_use") {
     const state = part.state ?? {}
     const input = JSON.stringify(state.input ?? {}, null, 2)
-    const output = state.output ?? state.error ?? ""
+    const output = stripLsp(state.output ?? state.error ?? "")
     return `# input\n${input}\n\n# output\n${output}`
   }
   return JSON.stringify(obj, null, 2)
+}
+
+// Drop the LSP/type-checker diagnostics opencode appends to write/edit output —
+// false positives that otherwise pollute retrieval (composer feedback).
+function stripLsp(text: string): string {
+  return text
+    .replace(/<diagnostics\b[^>]*>[\s\S]*?<\/diagnostics>/g, "")
+    .replace(/\n*LSP errors detected[^\n]*/g, "")
+    .replace(/\s+$/, "")
 }
 
 function sliceText(text: string, head?: number, tail?: number, range?: string): string {

--- a/dlab/js/digest-get.ts
+++ b/dlab/js/digest-get.ts
@@ -11,12 +11,13 @@ const { join } = require("path")
 
 export default tool({
   description:
-    "Retrieve a single log element by its digest ID (the [tN]/[xN]/[rN]/[p0] ids in _digest/digest.md). " +
-    "IDs are fully qualified, e.g. 'main/t2', 'poet.r1.i2/x8', 'poet.r1.i2/r11'. Returns the decoded payload: " +
-    "for a tool call (tN) its input plus clean stdout/stderr; for a raw_text stream (rN) the verbatim " +
-    "stdout/stderr the run emitted — this is what you embed as a cell's stream output; for a text id (xN) " +
-    "the verbatim reasoning; for p0 the full prompt. Use head/tail/range to slice long output (e.g. a PyMC " +
-    "fit log) instead of paying for all of it.",
+    "Retrieve a single log element by its digest ID (the [tN]/[xN]/[rN]/[aN]/[p0] ids in _digest/digest.md). " +
+    "IDs are fully qualified, e.g. 'main/t2', 'poet.r1.i2/x8', 'poet.r1.i2/r11', 'poet.r1.i2/a5'. Returns the " +
+    "decoded payload: for a tool call (tN) its input plus clean stdout/stderr; for a raw_text stream (rN) the " +
+    "verbatim stdout/stderr the run emitted — this is what you embed as a cell's stream output; for a text id " +
+    "(xN) the verbatim reasoning; for a small artifact file (aN, e.g. a results .json/.csv/.md) its contents; " +
+    "for p0 the full prompt. Read the shape hint next to an artifact in the digest first, then use " +
+    "head/tail/range to slice instead of pulling the whole file.",
 
   args: {
     id: tool.schema.string().describe("Fully-qualified digest ID, e.g. 'poet.r1.i2/r11'"),
@@ -36,14 +37,23 @@ export default tool({
     const entry = index[id]
     if (!entry) return `ERROR: unknown digest id '${id}'`
 
-    let selected: string[]
+    let content: string
     try {
-      const content = readFileSync(join(cwd, entry.log_file), "utf-8").split("\n")
-      const end = entry.line_end ?? entry.line_no
-      selected = content.slice(entry.line_no - 1, end) // 1-based inclusive
+      content = readFileSync(join(cwd, entry.log_file), "utf-8")
     } catch {
       return `ERROR: cannot read ${entry.log_file}`
     }
+
+    // artifact: an id pointing at a small result file (json/csv/md) — return its
+    // whole content, sliced. The composer read the shape hint in the digest to
+    // decide it wanted this; head/tail/range keep it from over-reading.
+    if (entry.event_type === "artifact") {
+      return sliceText(content.replace(/\s+$/, ""), head, tail, range)
+    }
+
+    const lines = content.split("\n")
+    const end = entry.line_end ?? entry.line_no
+    const selected = lines.slice(entry.line_no - 1, end) // 1-based inclusive
 
     // raw_text: a block of plain stdout/stderr lines, no JSON. Strip the
     // [STDERR] markers so it reads as clean output ready to embed.

--- a/dlab/js/digest-get.ts
+++ b/dlab/js/digest-get.ts
@@ -1,0 +1,78 @@
+import { tool } from "@opencode-ai/plugin"
+// Use require() for Node builtins — ESM imports break under Bun's strict interop
+const { readFileSync } = require("fs")
+const { join } = require("path")
+
+// Deliberately dumb retrieval tool (issue #85): the host-side Python digest
+// owns all the intelligence and writes _digest/index.json mapping every ID to
+// {log_file, line_no, event_type}. This tool just looks up one ID, reads that
+// single NDJSON line, extracts the payload, and renders it DECODED (clean
+// stdout/stderr, not escaped JSON) with optional slicing.
+
+export default tool({
+  description:
+    "Retrieve a single log element by its digest ID (the [t.]/[x.]/[p0] ids in _digest/digest.md). " +
+    "IDs are fully qualified, e.g. 'main/t2' or 'poet.r1.i2/x8'. Returns the decoded payload: " +
+    "for a tool call, its input plus clean stdout/stderr; for a text/reasoning id, the verbatim text; " +
+    "for p0, the full prompt. Use head/tail/range to slice long output (e.g. a PyMC fit log) " +
+    "instead of paying for all of it.",
+
+  args: {
+    id: tool.schema.string().describe("Fully-qualified digest ID, e.g. 'poet.r1.i2/t7'"),
+    head: tool.schema.number().optional().describe("Return only the first N lines of the payload"),
+    tail: tool.schema.number().optional().describe("Return only the last N lines of the payload"),
+    range: tool.schema.string().optional().describe("Return lines A-B of the payload, e.g. '10-40'"),
+  },
+
+  async execute({ id, head, tail, range }) {
+    const cwd = process.cwd()
+    let index: Record<string, { log_file: string; line_no: number; event_type: string }>
+    try {
+      index = JSON.parse(readFileSync(join(cwd, "_digest", "index.json"), "utf-8"))
+    } catch {
+      return "ERROR: _digest/index.json not found — generate the digest first."
+    }
+    const entry = index[id]
+    if (!entry) return `ERROR: unknown digest id '${id}'`
+
+    let rawLine: string
+    try {
+      const content = readFileSync(join(cwd, entry.log_file), "utf-8")
+      rawLine = content.split("\n")[entry.line_no - 1] ?? ""
+    } catch {
+      return `ERROR: cannot read ${entry.log_file}`
+    }
+
+    let obj: any
+    try {
+      obj = JSON.parse(rawLine)
+    } catch {
+      return sliceText(rawLine, head, tail, range) // non-JSON line: return as-is
+    }
+    return sliceText(renderPayload(obj, entry.event_type), head, tail, range)
+  },
+})
+
+function renderPayload(obj: any, eventType: string): string {
+  const part = obj.part ?? {}
+  if (eventType === "text") return String(part.text ?? "")
+  if (eventType === "dlab_start") return String(obj.prompt ?? part.prompt ?? "")
+  if (eventType === "tool_use") {
+    const state = part.state ?? {}
+    const input = JSON.stringify(state.input ?? {}, null, 2)
+    const output = state.output ?? state.error ?? ""
+    return `# input\n${input}\n\n# output\n${output}`
+  }
+  return JSON.stringify(obj, null, 2)
+}
+
+function sliceText(text: string, head?: number, tail?: number, range?: string): string {
+  const lines = text.split("\n")
+  if (range) {
+    const [a, b] = range.split("-").map((n) => parseInt(n, 10))
+    return lines.slice(a - 1, b).join("\n")
+  }
+  if (head) return lines.slice(0, head).join("\n")
+  if (tail) return lines.slice(-tail).join("\n")
+  return text
+}

--- a/dlab/js/digest-get.ts
+++ b/dlab/js/digest-get.ts
@@ -13,7 +13,8 @@ export default tool({
   description:
     "Retrieve a single log element by its digest ID (the [tN]/[xN]/[rN]/[aN]/[p0] ids in _digest/digest.md). " +
     "IDs are fully qualified, e.g. 'main/t2', 'poet.r1.i2/x8', 'poet.r1.i2/r11', 'poet.r1.i2/a5'. Returns the " +
-    "decoded payload: for a tool call (tN) its input plus clean stdout/stderr; for a raw_text stream (rN) the " +
+    "decoded payload: for a tool call (tN) its input plus clean stdout/stderr — and for a CUSTOM tool, the " +
+    "code the tool ran (its implementation), so you can reproduce it in a notebook cell; for a raw_text stream (rN) the " +
     "verbatim stdout/stderr the run emitted — this is what you embed as a cell's stream output; for a text id " +
     "(xN) the verbatim reasoning; for a small artifact file (aN, e.g. a results .json/.csv/.md) its contents; " +
     "for p0 the full prompt. Read the shape hint next to an artifact in the digest first, then use " +
@@ -28,7 +29,7 @@ export default tool({
 
   async execute({ id, head, tail, range }) {
     const cwd = process.cwd()
-    let index: Record<string, { log_file: string; line_no: number; line_end?: number; event_type: string }>
+    let index: Record<string, { log_file: string; line_no: number; line_end?: number; event_type: string; tool_source?: string }>
     try {
       index = JSON.parse(readFileSync(join(cwd, "_digest", "index.json"), "utf-8"))
     } catch {
@@ -69,7 +70,16 @@ export default tool({
     } catch {
       return sliceText(rawLine, head, tail, range) // non-JSON line: return as-is
     }
-    return sliceText(renderPayload(obj, entry.event_type), head, tail, range)
+    let payload = renderPayload(obj, entry.event_type)
+    // Custom tool: append the code the tool actually ran (its implementation),
+    // so one retrieval gives "the call was XXX and this is the code it ran: YYY".
+    if (entry.event_type === "tool_use" && entry.tool_source) {
+      try {
+        const impl = readFileSync(join(cwd, entry.tool_source), "utf-8")
+        payload += `\n\n# the code this tool ran (${entry.tool_source})\n${impl}`
+      } catch {}
+    }
+    return sliceText(payload, head, tail, range)
   },
 })
 

--- a/dlab/session_digest.py
+++ b/dlab/session_digest.py
@@ -201,7 +201,7 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
         for t in reversed(texts):
             s = t.replace("[STDERR]", "").strip()
             if s:
-                tail = _truncate(s, 80)
+                tail = _tail_line(s, 80)
                 break
         block = {"id": rid, "n_lines": len(texts),
                  "stream": "stderr" if is_err else "stdout", "tail": tail}
@@ -292,21 +292,37 @@ def _tool_call(tid: str, name: str, ev: LogEvent) -> dict[str, Any]:
     else:
         raw_summary = inp.get("filePath") or inp.get("description") or inp.get("command") or ""
         summary = " ".join(str(raw_summary).split())
+    # Compact input signature for custom tools — the call's args (paths, flags)
+    # are exactly what a notebook cell needs to reproduce it, and were otherwise
+    # invisible until retrieved (composer feedback). bash/write/edit already
+    # carry their arg in `summary`.
+    input_sig = ""
+    if name not in ("bash", "write", "edit"):
+        parts = []
+        for k, v in inp.items():
+            if isinstance(v, (bool, int, float)):
+                parts.append(f"{k}={v}")
+            elif isinstance(v, str):
+                parts.append(f"{k}={_short_value(v, 40)}")
+            else:
+                parts.append(k)
+        input_sig = ", ".join(parts)
     start = end = None
     tt = ev.part.get("state", {}).get("time", {}) if isinstance(ev.part, dict) else {}
     if isinstance(tt, dict):
         start, end = tt.get("start"), tt.get("end")
     dur = (end - start) / 1000 if start and end else None
-    out = get_tool_output(ev) or ""
-    err = get_tool_error(ev) or ""
+    out = _strip_lsp(get_tool_output(ev) or "")
+    err = _strip_lsp(get_tool_error(ev) or "")
     stream = err if err else out
+    stream_lines = stream.splitlines()
     return {
         "id": tid, "name": name, "summary": summary, "ok": ok,
         "status": status, "start": start, "end": end, "duration_s": dur,
-        "raw_ids": [],
+        "input_sig": input_sig, "raw_ids": [],
         "out_stream": "stderr" if err else "stdout",
-        "out_n_lines": len(stream.splitlines()) if stream else 0,
-        "out_tail": _truncate(stream.splitlines()[-1].strip(), 80) if stream else "",
+        "out_n_lines": len(stream_lines),
+        "out_tail": _tail_line(stream_lines[-1].strip(), 80) if stream_lines else "",
     }
 
 
@@ -350,9 +366,12 @@ def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
             cons_log = d / "consolidator.log"
             if cons_log.exists():
                 qual = f"{agent}.r{round_idx}.cons"
+                cons_ok = (work_dir / f"parallel/run-{ts}"
+                           / "consolidated_summary.md").exists()
                 agents.append(_digest_agent(
                     qual, agent, f"{agent} consolidator{retry}",
                     cons_log, work_dir, f"parallel/run-{ts}", run_id=d.name,
+                    summary_ok=cons_ok,
                 ))
     return agents
 
@@ -571,7 +590,12 @@ def _render_tree(work_dir: Path, agents: list[_AgentDigest]) -> list[str]:
         lines.append(f"  - parallel fan-out: **{agent}** ({run_key})")
         for a in members:
             if a.qual.endswith(".cons"):
-                lines.append(f"    - {a.qual}: {a.duration_s:.0f}s, ${a.cost:.3f} — consolidator")
+                cons_tail = ("" if a.summary_ok
+                             else " — NO consolidated_summary.md (treat as failed)")
+                lines.append(
+                    f"    - {a.qual}: {a.duration_s:.0f}s, ${a.cost:.3f} "
+                    f"— consolidator{cons_tail}"
+                )
             else:
                 status = "summary written" if a.summary_ok else "NO summary.md (treat as failed)"
                 lines.append(
@@ -653,6 +677,8 @@ def _render_tool_call(tc: dict[str, Any]) -> str:
     row = f"[{tc['id']}] {tc['name']}"
     if tc["summary"]:
         row += f" `{tc['summary']}`" if tc["name"] == "bash" else f" {tc['summary']}"
+    if tc.get("input_sig"):
+        row += f" {{{tc['input_sig']}}}"
     # write/edit are instantaneous file ops — no status/stream to show.
     if tc["name"] not in ("write", "edit"):
         mark = "✓" if tc["ok"] else "✗ error"
@@ -714,6 +740,45 @@ def _basename(path: str) -> str:
 def _truncate(text: str, n: int) -> str:
     text = " ".join(text.split())
     return text if len(text) <= n else text[: n - 1] + "…"
+
+
+_ERROR_MARKERS = ("Error", "Exception", "Traceback", "Errno", "assert",
+                  "Failed", "FAILED")
+
+
+def _short_value(v: str, n: int) -> str:
+    """Shorten an input value; for a path keep the END (the filename is the
+    reproducible part), otherwise keep the start."""
+    v = " ".join(v.split())
+    if len(v) <= n:
+        return v
+    if "/" in v:
+        return "…" + v[-(n - 1):]
+    return v[: n - 1] + "…"
+
+
+def _tail_line(text: str, n: int) -> str:
+    """Truncate to n chars, but for an error-like line keep the END — the
+    payload of a traceback (the exception, the offending key) is its tail, and
+    head-truncation cut it off exactly where it mattered (composer feedback)."""
+    text = " ".join(text.split())
+    if len(text) <= n:
+        return text
+    if any(m in text for m in _ERROR_MARKERS):
+        return "…" + text[-(n - 1):]
+    return text[: n - 1] + "…"
+
+
+_DIAG_RE = re.compile(r"<diagnostics\b[^>]*>.*?</diagnostics>", re.DOTALL)
+_LSP_RE = re.compile(r"\n*LSP errors detected[^\n]*")
+
+
+def _strip_lsp(text: str) -> str:
+    """Drop the LSP/type-checker diagnostics block opencode appends to
+    write/edit output — false positives that otherwise pollute retrieval."""
+    text = _DIAG_RE.sub("", text)
+    text = _LSP_RE.sub("", text)
+    return text.rstrip()
 
 
 def _human_size(n: int) -> str:

--- a/dlab/session_digest.py
+++ b/dlab/session_digest.py
@@ -46,6 +46,11 @@ DIGEST_GET_SOURCE: str = files("dlab.js").joinpath("digest-get.ts").read_text()
 
 _EXCERPT_LEN = 160
 _TASK_LEN = 240
+# Tools that navigate/inspect rather than produce durable output — shown as a
+# one-line count, not labeled rows (they never own an artifact).
+_NAV_TOOLS = {
+    "read", "glob", "list", "grep", "todowrite", "todoread", "webfetch",
+}
 # Work-dir entries that are session internals, not agent artifacts.
 _ROOT_SKIP = {
     "_opencode_logs", "_digest", "_docker", "_hooks", ".opencode",
@@ -74,7 +79,7 @@ class _AgentDigest:
     task_text: str | None                       # differentiating prompt (p0)
     task_line: int | None
     tool_counter: Counter                       # tool name -> n
-    script_runs: list[dict[str, Any]]           # bash calls
+    tool_calls: list[dict[str, Any]]            # every tool_use (with raw_ids)
     excerpts: list[tuple[str, str]]             # (id, truncated text)
     index: dict[str, dict[str, Any]]            # local ids -> pointer
     # attribution inputs (cross-agent pass fills ``artifacts`` from these)
@@ -168,14 +173,49 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
     task_text: str | None = None
     task_line: int | None = None
     tool_counter: Counter = Counter()
-    script_runs: list[dict[str, Any]] = []
+    tool_calls: list[dict[str, Any]] = []
+    by_tid: dict[str, dict[str, Any]] = {}
     writes: dict[str, list[str]] = {}
     excerpts: list[tuple[str, str]] = []
     index: dict[str, dict[str, Any]] = {}
+    pending_raw: list[tuple[int, str]] = []
+    last_tid: str | None = None
+
+    def flush_raw() -> None:
+        # A run of consecutive raw_text lines (stdout/stderr the process emitted
+        # outside the tool events) becomes ONE r-id on the shared counter,
+        # indexed as a line range, and mapped to the most recent tool call.
+        nonlocal counter, last_tid
+        if not pending_raw:
+            return
+        counter += 1
+        rid = f"r{counter}"
+        first_ln, last_ln = pending_raw[0][0], pending_raw[-1][0]
+        texts = [t for _, t in pending_raw]
+        index[f"{qual}/{rid}"] = {
+            "log_file": log_rel, "line_no": first_ln, "line_end": last_ln,
+            "event_type": "raw_text",
+        }
+        is_err = any(t.startswith("[STDERR]") for t in texts)
+        tail = ""
+        for t in reversed(texts):
+            s = t.replace("[STDERR]", "").strip()
+            if s:
+                tail = _truncate(s, 80)
+                break
+        block = {"id": rid, "n_lines": len(texts),
+                 "stream": "stderr" if is_err else "stdout", "tail": tail}
+        if last_tid is not None and last_tid in by_tid:
+            by_tid[last_tid]["raw_ids"].append(block)
+        pending_raw.clear()
 
     for ie in indexed:
         ev = ie.event
         et = ev.event_type
+        if et == "raw_text":
+            pending_raw.append((ie.line_no, ev.part.get("text", "")))
+            continue
+        flush_raw()  # any structured event ends the current raw_text block
         if et == "dlab_start":
             model = ev.raw.get("model") or ev.part.get("model")
             prompt = ev.raw.get("prompt") or ev.part.get("prompt") or ""
@@ -198,8 +238,10 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
             tool_count += 1
             name = get_tool_name(ev) or "?"
             tool_counter[name] += 1
-            if name == "bash":
-                script_runs.append(_script_run(tid, ev))
+            tc = _tool_call(tid, name, ev)
+            tool_calls.append(tc)
+            by_tid[tid] = tc
+            last_tid = tid
             if name in ("write", "edit"):
                 fp = (get_tool_input(ev) or {}).get("filePath")
                 if fp:
@@ -215,6 +257,7 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
             txt = (get_text(ev) or "").strip()
             if txt:
                 excerpts.append((xid, _truncate(txt, _EXCERPT_LEN)))
+    flush_raw()  # trailing raw_text block
 
     ts = [ie.event.timestamp for ie in indexed if ie.event.timestamp]
     duration_s = (max(ts) - min(ts)) / 1000 if len(ts) > 1 else 0.0
@@ -227,37 +270,43 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
         qual=qual, role=role, heading=heading, log_rel=log_rel,
         workdir_rel=workdir_rel, model=model, duration_s=duration_s, cost=cost,
         tool_count=tool_count, task_text=task_text, task_line=task_line,
-        tool_counter=tool_counter, script_runs=script_runs,
+        tool_counter=tool_counter, tool_calls=tool_calls,
         excerpts=excerpts, index=index, run_id=run_id, start_ts=start_ts,
         log_path=log_path, workdir_base=base, writes=writes,
         disk_files=disk_files, summary_ok=summary_ok,
     )
 
 
-def _script_run(tid: str, ev: LogEvent) -> dict[str, Any]:
+def _tool_call(tid: str, name: str, ev: LogEvent) -> dict[str, Any]:
+    """Capture one tool_use: label, status, time window (for artifact
+    provenance), and a fallback for its structured output (raw_text, when
+    present, is attached separately and preferred at render time)."""
+    from dlab.opencode_logparser import get_tool_output
     inp = get_tool_input(ev) or {}
     status = get_tool_status(ev)
     ok = status == "completed" and not get_tool_error(ev)
-    from dlab.opencode_logparser import get_tool_output
-    out = get_tool_output(ev) or ""
-    err = get_tool_error(ev) or ""
-    stream = err if err else out
-    n_lines = len(stream.splitlines()) if stream else 0
-    which = "stderr" if err else "stdout"
-    tail = ""
-    if stream:
-        last = stream.splitlines()[-1].strip()
-        tail = _truncate(last, 80)
-    start, end = None, None
+    if name == "bash":
+        summary = " ".join((inp.get("command") or inp.get("description") or "").split())
+    elif name in ("write", "edit"):
+        summary = _basename(inp.get("filePath") or "")
+    else:
+        raw_summary = inp.get("filePath") or inp.get("description") or inp.get("command") or ""
+        summary = " ".join(str(raw_summary).split())
+    start = end = None
     tt = ev.part.get("state", {}).get("time", {}) if isinstance(ev.part, dict) else {}
     if isinstance(tt, dict):
         start, end = tt.get("start"), tt.get("end")
     dur = (end - start) / 1000 if start and end else None
+    out = get_tool_output(ev) or ""
+    err = get_tool_error(ev) or ""
+    stream = err if err else out
     return {
-        "id": tid,
-        "cmd": inp.get("command") or inp.get("description") or "",
-        "ok": ok, "duration_s": dur, "stream": which,
-        "n_lines": n_lines, "tail": tail,
+        "id": tid, "name": name, "summary": summary, "ok": ok,
+        "status": status, "start": start, "end": end, "duration_s": dur,
+        "raw_ids": [],
+        "out_stream": "stderr" if err else "stdout",
+        "out_n_lines": len(stream.splitlines()) if stream else 0,
+        "out_tail": _truncate(stream.splitlines()[-1].strip(), 80) if stream else "",
     }
 
 
@@ -358,16 +407,62 @@ def _scan_mentions(log_path: Path, pattern: "re.Pattern | None") -> dict[str, in
     return mentions
 
 
+def _producing_call(mtime_ms: float, tool_calls: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """The tool call whose [start, end] window contains the file's mtime — i.e.
+    the call that wrote it. Strict containment wins; a small grace catches
+    instant ops (a fast ``cp``) whose recorded window is sub-millisecond while
+    mtime is only second-granular. Navigational calls are excluded (they never
+    write). The latest-starting match wins (the final writer). Only used on files
+    already proven *produced*, so mtime cannot be misled by a copy.
+    """
+    grace = 2000  # ms
+    strict: dict[str, Any] | None = None
+    loose: dict[str, Any] | None = None
+    for tc in tool_calls:
+        if tc["name"] in _NAV_TOOLS:
+            continue
+        s, e = tc.get("start"), tc.get("end")
+        if s is None or e is None:
+            continue
+        if s <= mtime_ms <= e:
+            if strict is None or s >= strict["start"]:
+                strict = tc
+        elif s - grace <= mtime_ms <= e + grace:
+            if loose is None or s >= loose["start"]:
+                loose = tc
+    return strict or loose
+
+
+def _provenance(f: Path, name: str, agent: _AgentDigest) -> str | None:
+    """How this artifact was produced: the write/edit chain if a tool wrote it,
+    else the ``from tN`` call whose window contains its mtime (bash/custom/cp)."""
+    chain = agent.writes.get(name)
+    if chain:
+        return ", ".join(chain)
+    try:
+        mtime_ms = f.stat().st_mtime * 1000
+    except OSError:
+        return None
+    pc = _producing_call(mtime_ms, agent.tool_calls)
+    if pc is None:
+        return None
+    label = pc["name"]
+    if pc["summary"]:
+        label += f": {_truncate(pc['summary'], 40)}"
+    return f"from {pc['id']} ({label})"
+
+
 def _attribute_artifacts(agents: list[_AgentDigest], work_dir: Path) -> None:
-    """Fill each agent's ``artifacts`` list, dropping inherited copies.
+    """Fill each agent's ``artifacts`` list: link every file to the tool call
+    that produced it, and drop untouched inherited copies.
 
     A file ``f`` in agent ``A`` is *inherited* iff some agent **outside A's
     fan-out run** mentioned ``f``'s name **before A started** (chronology +
     sibling isolation — the later ``cp`` that lifts an instance's output to the
-    root cannot steal authorship, and isolated siblings cannot seed each other).
-    An inherited file is dropped only when it is byte-identical to the
-    workspace-root copy that seeded A; if A changed it, that is real derived
-    work and it is kept, flagged ``modified from inherited``.
+    root cannot steal authorship, and isolated siblings cannot seed each other)
+    AND the workspace root holds it at the same path. It is dropped only when
+    byte-identical to that seed; if A changed it, it is kept and flagged
+    ``modified from inherited`` (its edit/producing call is the provenance).
     """
     universe = {f.name for a in agents for f in a.disk_files}
     pattern = (
@@ -386,10 +481,6 @@ def _attribute_artifacts(agents: list[_AgentDigest], work_dir: Path) -> None:
             rel = str(f.relative_to(a.workdir_base))
             name = f.name
             seen.add(name)
-            # Inheritance needs BOTH: an external (non-sibling) agent named the
-            # file before A started (so it pre-existed A's work, not a basename
-            # collision with an independently-produced sibling/later file), AND
-            # the workspace-root seed actually holds it at the same path.
             foreign = [b.mentions[name] for b in agents
                        if b is not a and b.run_id != a.run_id
                        and name in b.mentions]
@@ -404,13 +495,13 @@ def _attribute_artifacts(agents: list[_AgentDigest], work_dir: Path) -> None:
             except OSError:
                 size = None
             arts.append({"path": rel, "size": size,
-                         "chain": a.writes.get(name), "note": note})
+                         "provenance": _provenance(f, name, a), "note": note})
         # Files written via tool but no longer on disk (renamed/deleted) keep
         # their provenance so the story isn't lost.
         for nm, chain in sorted(a.writes.items()):
             if nm not in seen:
-                arts.append({"path": nm, "size": None, "chain": chain,
-                             "note": None})
+                arts.append({"path": nm, "size": None,
+                             "provenance": ", ".join(chain), "note": None})
         a.artifacts = arts
 
 
@@ -528,43 +619,60 @@ def _render_agent(a: _AgentDigest, brief: bool) -> list[str]:
             bits: list[str] = []
             if art["size"] is not None:
                 bits.append(_human_size(art["size"]))
-            if art["chain"]:
-                bits.extend(art["chain"])
+            if art.get("provenance"):
+                bits.append(f"← {art['provenance']}")
             if art.get("note"):
                 bits.append(art["note"])
             meta = ", ".join(bits) if bits else "—"
             lines.append(f"- [a{i}] {art['path']} ({meta})")
         lines.append("")
 
-    if a.script_runs:
-        lines.append("**Script runs**")
-        for s in a.script_runs:
-            mark = "✓" if s["ok"] else "✗ error"
-            dur = f"{s['duration_s']:.0f}s" if s["duration_s"] is not None else ""
-            detail = f"{s['stream']} {s['n_lines']} lines" if s["n_lines"] else "no output"
-            if s["tail"]:
-                detail += f" — {s['tail']}"
-            # Full command verbatim (whitespace-collapsed to one line) — the
-            # composer needs the exact command that ran, not a preview.
-            cmd = " ".join(s["cmd"].split())
-            lines.append(f"- [{s['id']}] bash `{cmd}`  {mark}  {dur}  ({detail})")
-        lines.append("")
-
+    producing = [tc for tc in a.tool_calls if tc["name"] not in _NAV_TOOLS]
     if brief:
         counts = ", ".join(f"{k}×{v}" for k, v in a.tool_counter.most_common())
         if counts:
             lines.append(f"**Tool calls**: {counts}")
-    else:
-        other = {k: v for k, v in a.tool_counter.items() if k not in ("bash",)}
-        if other:
-            counts = ", ".join(f"{k}×{v}" for k, v in Counter(other).most_common())
-            lines.append(f"**Other tool calls**: {counts}")
+    elif producing:
+        lines.append("**Tool calls**")
+        for tc in producing:
+            lines.append("- " + _render_tool_call(tc))
+        nav = {k: v for k, v in a.tool_counter.items() if k in _NAV_TOOLS}
+        if nav:
+            counts = ", ".join(f"{k}×{v}" for k, v in Counter(nav).most_common())
+            lines.append(f"**Navigational**: {counts}")
 
     if a.excerpts:
         lines.append("**Reasoning excerpts**")
         for xid, txt in a.excerpts:
             lines.append(f"- [{xid}] \"{txt}\"")
     return lines
+
+
+def _render_tool_call(tc: dict[str, Any]) -> str:
+    """One labeled Tool-calls row, with its mapped raw_text stream(s)."""
+    row = f"[{tc['id']}] {tc['name']}"
+    if tc["summary"]:
+        row += f" `{tc['summary']}`" if tc["name"] == "bash" else f" {tc['summary']}"
+    # write/edit are instantaneous file ops — no status/stream to show.
+    if tc["name"] not in ("write", "edit"):
+        mark = "✓" if tc["ok"] else "✗ error"
+        dur = f"{tc['duration_s']:.0f}s" if tc["duration_s"] is not None else ""
+        row += f"  {mark}"
+        if dur:
+            row += f"  {dur}"
+    for blk in tc["raw_ids"]:
+        detail = f"{blk['stream']} {blk['n_lines']} ln"
+        if blk["tail"]:
+            detail += f" — {blk['tail']}"
+        row += f"  → {blk['id']} ({detail})"
+    # Fall back to the tool's structured output only when no raw_text mapped in,
+    # and never for write/edit (their output is just a "Wrote file" confirmation).
+    if not tc["raw_ids"] and tc["out_n_lines"] and tc["name"] not in ("write", "edit"):
+        detail = f"{tc['out_stream']} {tc['out_n_lines']} ln"
+        if tc["out_tail"]:
+            detail += f" — {tc['out_tail']}"
+        row += f"  ({detail})"
+    return row
 
 
 # ---------------------------------------------------------------------------

--- a/dlab/session_digest.py
+++ b/dlab/session_digest.py
@@ -17,9 +17,11 @@ ID scheme (spec §7.1): one shared counter per agent — ``t07`` (tool call),
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
@@ -73,10 +75,18 @@ class _AgentDigest:
     task_line: int | None
     tool_counter: Counter                       # tool name -> n
     script_runs: list[dict[str, Any]]           # bash calls
-    writes: dict[str, list[str]]                # file -> ["written t6", ...]
     excerpts: list[tuple[str, str]]             # (id, truncated text)
     index: dict[str, dict[str, Any]]            # local ids -> pointer
+    # attribution inputs (cross-agent pass fills ``artifacts`` from these)
+    run_id: str | None                          # fan-out run; siblings share it
+    start_ts: int                               # first event timestamp
+    log_path: Path                              # for the mention scan
+    workdir_base: Path                          # dir walked for artifacts
+    writes: dict[str, list[str]]                # basename -> ["written t6", ...]
+    disk_files: list[Path]                      # files present in the workdir
     summary_ok: bool = True
+    mentions: dict[str, int] = field(default_factory=dict)   # basename -> ts
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -119,8 +129,34 @@ def _differentiating_prompt(full_prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _walk_workdir_files(base: Path) -> list[Path]:
+    """Every real file in an agent's workdir, pruning session internals.
+
+    Enumerating the workdir on disk (not just tool inputs) is what surfaces
+    script-produced outputs (figures, ``.nc``, ``.parquet``, ``roas.csv``):
+    those never pass through a ``write``/``edit`` tool call, so a log-only view
+    misses them. Session-internal dirs (``data``, ``_hooks``, ``parallel``, …)
+    are pruned, and ``instance-*`` subdirs are skipped so a consolidator whose
+    workdir is the run root does not swallow its siblings' files.
+    """
+    files: list[Path] = []
+    if not base.is_dir():
+        return files
+    for entry in sorted(base.iterdir()):
+        if entry.name in _ROOT_SKIP or entry.name.startswith("."):
+            continue
+        if entry.is_file():
+            files.append(entry)
+        elif entry.is_dir() and not entry.name.startswith("instance-"):
+            for sub in sorted(entry.rglob("*")):
+                rel_parts = sub.relative_to(base).parts
+                if sub.is_file() and not any(p.startswith(".") for p in rel_parts):
+                    files.append(sub)
+    return files
+
+
 def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
-                  work_dir: Path, workdir_rel: str | None,
+                  work_dir: Path, workdir_rel: str | None, run_id: str | None,
                   summary_ok: bool = True) -> _AgentDigest:
     indexed = _iter_indexed(log_path)
     log_rel = _rel(log_path, work_dir)
@@ -182,13 +218,19 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
 
     ts = [ie.event.timestamp for ie in indexed if ie.event.timestamp]
     duration_s = (max(ts) - min(ts)) / 1000 if len(ts) > 1 else 0.0
+    start_ts = min(ts) if ts else 0
+
+    base = (work_dir / workdir_rel) if workdir_rel else work_dir
+    disk_files = _walk_workdir_files(base)
 
     return _AgentDigest(
         qual=qual, role=role, heading=heading, log_rel=log_rel,
         workdir_rel=workdir_rel, model=model, duration_s=duration_s, cost=cost,
         tool_count=tool_count, task_text=task_text, task_line=task_line,
-        tool_counter=tool_counter, script_runs=script_runs, writes=writes,
-        excerpts=excerpts, index=index, summary_ok=summary_ok,
+        tool_counter=tool_counter, script_runs=script_runs,
+        excerpts=excerpts, index=index, run_id=run_id, start_ts=start_ts,
+        log_path=log_path, workdir_base=base, writes=writes,
+        disk_files=disk_files, summary_ok=summary_ok,
     )
 
 
@@ -232,6 +274,7 @@ def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
     if main_log.exists():
         agents.append(_digest_agent(
             "main", "orchestrator", "orchestrator", main_log, work_dir, None,
+            run_id=None,
         ))
 
     # Group parallel run dirs by agent name; rank timestamps → round number.
@@ -252,16 +295,123 @@ def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
                 summary_ok = (work_dir / inst_work / "summary.md").exists()
                 agents.append(_digest_agent(
                     qual, agent, f"{agent}, instance {n}{retry}",
-                    inst_log, work_dir, inst_work, summary_ok,
+                    inst_log, work_dir, inst_work, run_id=d.name,
+                    summary_ok=summary_ok,
                 ))
             cons_log = d / "consolidator.log"
             if cons_log.exists():
                 qual = f"{agent}.r{round_idx}.cons"
                 agents.append(_digest_agent(
                     qual, agent, f"{agent} consolidator{retry}",
-                    cons_log, work_dir, f"parallel/run-{ts}", True,
+                    cons_log, work_dir, f"parallel/run-{ts}", run_id=d.name,
                 ))
     return agents
+
+
+# ---------------------------------------------------------------------------
+# Artifact attribution (produced vs. inherited)
+# ---------------------------------------------------------------------------
+
+
+def _file_sha256(path: Path) -> str | None:
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _same_content(a: Path, b: Path) -> bool:
+    """True iff both files exist with identical size and sha256."""
+    try:
+        if not b.is_file() or a.stat().st_size != b.stat().st_size:
+            return False
+    except OSError:
+        return False
+    ha = _file_sha256(a)
+    return ha is not None and ha == _file_sha256(b)
+
+
+def _scan_mentions(log_path: Path, pattern: "re.Pattern | None") -> dict[str, int]:
+    """Earliest timestamp at which each known basename appears anywhere in this
+    agent's events — bash commands, tool ``filePath``s, the contents of scripts
+    it wrote, and tool outputs (all live in the raw NDJSON line)."""
+    mentions: dict[str, int] = {}
+    if pattern is None:
+        return mentions
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return mentions
+    for line in text.splitlines():
+        ev = parse_line(line)
+        if ev is None or not ev.timestamp:
+            continue
+        ts = ev.timestamp
+        for m in pattern.finditer(line):
+            name = m.group(0)
+            if name not in mentions or ts < mentions[name]:
+                mentions[name] = ts
+    return mentions
+
+
+def _attribute_artifacts(agents: list[_AgentDigest], work_dir: Path) -> None:
+    """Fill each agent's ``artifacts`` list, dropping inherited copies.
+
+    A file ``f`` in agent ``A`` is *inherited* iff some agent **outside A's
+    fan-out run** mentioned ``f``'s name **before A started** (chronology +
+    sibling isolation — the later ``cp`` that lifts an instance's output to the
+    root cannot steal authorship, and isolated siblings cannot seed each other).
+    An inherited file is dropped only when it is byte-identical to the
+    workspace-root copy that seeded A; if A changed it, that is real derived
+    work and it is kept, flagged ``modified from inherited``.
+    """
+    universe = {f.name for a in agents for f in a.disk_files}
+    pattern = (
+        re.compile("|".join(re.escape(n) for n in
+                            sorted(universe, key=len, reverse=True)))
+        if universe else None
+    )
+    for a in agents:
+        a.mentions = _scan_mentions(a.log_path, pattern)
+
+    for a in agents:
+        arts: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for f in sorted(a.disk_files,
+                        key=lambda p: str(p.relative_to(a.workdir_base))):
+            rel = str(f.relative_to(a.workdir_base))
+            name = f.name
+            seen.add(name)
+            # Inheritance needs BOTH: an external (non-sibling) agent named the
+            # file before A started (so it pre-existed A's work, not a basename
+            # collision with an independently-produced sibling/later file), AND
+            # the workspace-root seed actually holds it at the same path.
+            foreign = [b.mentions[name] for b in agents
+                       if b is not a and b.run_id != a.run_id
+                       and name in b.mentions]
+            ref = work_dir / rel
+            note: str | None = None
+            if foreign and min(foreign) < a.start_ts and ref.is_file():
+                if _same_content(f, ref):
+                    continue  # untouched copy of the seed — drop silently
+                note = "modified from inherited"
+            try:
+                size: int | None = f.stat().st_size
+            except OSError:
+                size = None
+            arts.append({"path": rel, "size": size,
+                         "chain": a.writes.get(name), "note": note})
+        # Files written via tool but no longer on disk (renamed/deleted) keep
+        # their provenance so the story isn't lost.
+        for nm, chain in sorted(a.writes.items()):
+            if nm not in seen:
+                arts.append({"path": nm, "size": None, "chain": chain,
+                             "note": None})
+        a.artifacts = arts
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +438,7 @@ def build_digest(work_dir: str | Path, *, brief: bool = False) -> tuple[str, dic
     """
     work_dir = Path(work_dir)
     agents = _collect_agents(work_dir)
+    _attribute_artifacts(agents, work_dir)
     index: dict[str, dict[str, Any]] = {}
     for a in agents:
         index.update(a.index)
@@ -371,10 +522,18 @@ def _render_agent(a: _AgentDigest, brief: bool) -> list[str]:
         )
         lines.append("")
 
-    if a.writes:
-        lines.append("**Artifacts**")
-        for i, (fname, chain) in enumerate(sorted(a.writes.items()), start=1):
-            lines.append(f"- [a{i}] {fname} ({', '.join(chain)})")
+    if a.artifacts:
+        lines.append(f"**Artifacts** ({len(a.artifacts)})")
+        for i, art in enumerate(a.artifacts, start=1):
+            bits: list[str] = []
+            if art["size"] is not None:
+                bits.append(_human_size(art["size"]))
+            if art["chain"]:
+                bits.extend(art["chain"])
+            if art.get("note"):
+                bits.append(art["note"])
+            meta = ", ".join(bits) if bits else "—"
+            lines.append(f"- [a{i}] {art['path']} ({meta})")
         lines.append("")
 
     if a.script_runs:
@@ -385,7 +544,10 @@ def _render_agent(a: _AgentDigest, brief: bool) -> list[str]:
             detail = f"{s['stream']} {s['n_lines']} lines" if s["n_lines"] else "no output"
             if s["tail"]:
                 detail += f" — {s['tail']}"
-            lines.append(f"- [{s['id']}] bash `{_truncate(s['cmd'], 60)}`  {mark}  {dur}  ({detail})")
+            # Full command verbatim (whitespace-collapsed to one line) — the
+            # composer needs the exact command that ran, not a preview.
+            cmd = " ".join(s["cmd"].split())
+            lines.append(f"- [{s['id']}] bash `{cmd}`  {mark}  {dur}  ({detail})")
         lines.append("")
 
     if brief:

--- a/dlab/session_digest.py
+++ b/dlab/session_digest.py
@@ -167,7 +167,7 @@ def _walk_workdir_files(base: Path) -> list[Path]:
 
 def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
                   work_dir: Path, workdir_rel: str | None, run_id: str | None,
-                  summary_ok: bool = True) -> _AgentDigest:
+                  custom_tools: dict[str, str], summary_ok: bool = True) -> _AgentDigest:
     indexed = _iter_indexed(log_path)
     log_rel = _rel(log_path, work_dir)
 
@@ -236,14 +236,19 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
         elif et == "tool_use":
             counter += 1
             tid = f"t{counter}"
-            index[f"{qual}/{tid}"] = {
+            name = get_tool_name(ev) or "?"
+            entry = {
                 "log_file": log_rel, "line_no": ie.line_no,
                 "event_type": "tool_use",
             }
+            # Custom tool (has a .opencode/tools/<name>.ts): point at its source
+            # so digest-get returns the call AND the code the tool actually ran.
+            if name in custom_tools:
+                entry["tool_source"] = custom_tools[name]
+            index[f"{qual}/{tid}"] = entry
             tool_count += 1
-            name = get_tool_name(ev) or "?"
             tool_counter[name] += 1
-            tc = _tool_call(tid, name, ev)
+            tc = _tool_call(tid, name, ev, name in custom_tools)
             tool_calls.append(tc)
             by_tid[tid] = tc
             last_tid = tid
@@ -282,10 +287,12 @@ def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
     )
 
 
-def _tool_call(tid: str, name: str, ev: LogEvent) -> dict[str, Any]:
+def _tool_call(tid: str, name: str, ev: LogEvent, is_custom: bool = False) -> dict[str, Any]:
     """Capture one tool_use: label, status, time window (for artifact
     provenance), and a fallback for its structured output (raw_text, when
-    present, is attached separately and preferred at render time)."""
+    present, is attached separately and preferred at render time). ``is_custom``
+    flags a tool backed by a ``.opencode/tools/*.ts`` — its source (the code it
+    ran) is bundled into the tN retrieval, so the composer can reproduce it."""
     from dlab.opencode_logparser import get_tool_output
     inp = get_tool_input(ev) or {}
     status = get_tool_status(ev)
@@ -324,11 +331,24 @@ def _tool_call(tid: str, name: str, ev: LogEvent) -> dict[str, Any]:
     return {
         "id": tid, "name": name, "summary": summary, "ok": ok,
         "status": status, "start": start, "end": end, "duration_s": dur,
-        "input_sig": input_sig, "raw_ids": [],
+        "input_sig": input_sig, "custom": is_custom, "raw_ids": [],
         "out_stream": "stderr" if err else "stdout",
         "out_n_lines": len(stream_lines),
         "out_tail": _tail_line(stream_lines[-1].strip(), 80) if stream_lines else "",
     }
+
+
+def _custom_tool_sources(work_dir: Path) -> dict[str, str]:
+    """Map custom tool name → its ``.ts`` source path (relative to work_dir). A
+    tool is *custom* iff a ``.opencode/tools/<name>.ts`` exists — fully general,
+    no per-dpack knowledge. Built-in tools (bash/read/write/edit) have no such
+    file and are excluded; their "code" is already the command / file content."""
+    out: dict[str, str] = {}
+    tools_dir = work_dir / ".opencode" / "tools"
+    if tools_dir.is_dir():
+        for f in sorted(tools_dir.glob("*.ts")):
+            out[f.stem] = _rel(f, work_dir)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -339,12 +359,13 @@ def _tool_call(tid: str, name: str, ev: LogEvent) -> dict[str, Any]:
 def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
     logs_dir = work_dir / "_opencode_logs"
     agents: list[_AgentDigest] = []
+    custom_tools = _custom_tool_sources(work_dir)
 
     main_log = logs_dir / "main.log"
     if main_log.exists():
         agents.append(_digest_agent(
             "main", "orchestrator", "orchestrator", main_log, work_dir, None,
-            run_id=None,
+            run_id=None, custom_tools=custom_tools,
         ))
 
     # Group parallel run dirs by agent name; rank timestamps → round number.
@@ -366,7 +387,7 @@ def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
                 agents.append(_digest_agent(
                     qual, agent, f"{agent}, instance {n}{retry}",
                     inst_log, work_dir, inst_work, run_id=d.name,
-                    summary_ok=summary_ok,
+                    custom_tools=custom_tools, summary_ok=summary_ok,
                 ))
             cons_log = d / "consolidator.log"
             if cons_log.exists():
@@ -376,7 +397,7 @@ def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
                 agents.append(_digest_agent(
                     qual, agent, f"{agent} consolidator{retry}",
                     cons_log, work_dir, f"parallel/run-{ts}", run_id=d.name,
-                    summary_ok=cons_ok,
+                    custom_tools=custom_tools, summary_ok=cons_ok,
                 ))
     return agents
 
@@ -742,6 +763,9 @@ def _render_agent(a: _AgentDigest, brief: bool) -> list[str]:
 def _render_tool_call(tc: dict[str, Any]) -> str:
     """One labeled Tool-calls row, with its mapped raw_text stream(s)."""
     row = f"[{tc['id']}] {tc['name']}"
+    if tc.get("custom"):
+        # digest-get on this id also returns the tool's source (the code it ran)
+        row += " (custom)"
     if tc["summary"]:
         row += f" `{tc['summary']}`" if tc["name"] == "bash" else f" {tc['summary']}"
     if tc.get("input_sig"):

--- a/dlab/session_digest.py
+++ b/dlab/session_digest.py
@@ -56,6 +56,11 @@ _ROOT_SKIP = {
     "_opencode_logs", "_digest", "_docker", "_hooks", ".opencode",
     "parallel", "data", ".state.json", ".git",
 }
+# Small text artifacts get a retrievable id + a shape hint; bigger/binary ones
+# stay pointers (size only). The composer reads the shape to decide whether/what
+# to pull, then digest-get slices it — nothing lands in context unasked.
+_ARTIFACT_TEXT_EXT = {".json", ".csv", ".tsv", ".md", ".txt", ".yaml", ".yml"}
+_ARTIFACT_MAX_BYTES = 32 * 1024
 
 
 @dataclass
@@ -471,6 +476,50 @@ def _provenance(f: Path, name: str, agent: _AgentDigest) -> str | None:
     return f"from {pc['id']} ({label})"
 
 
+def _artifact_shape(path: Path, size: int | None) -> tuple[str | None, bool]:
+    """A cheap, deterministic 'what's in this file' hint for small text
+    artifacts, plus whether it should be retrievable. JSON → top-level keys,
+    CSV/TSV → header columns + row count, text → line count + first heading.
+    Returns (shape_or_None, retrievable). Big/binary files are neither."""
+    if (size is None or size > _ARTIFACT_MAX_BYTES
+            or path.suffix.lower() not in _ARTIFACT_TEXT_EXT):
+        return None, False
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None, False
+    ext = path.suffix.lower()
+    n_lines = len(text.splitlines())
+    if ext == ".json":
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError:
+            return f"{n_lines} lines", True
+        if isinstance(obj, dict):
+            keys = list(obj.keys())
+            shown = ", ".join(str(k) for k in keys[:8])
+            shape = f"keys: {shown}" + (" …" if len(keys) > 8 else "")
+        elif isinstance(obj, list):
+            shape = f"array of {len(obj)}"
+        else:
+            shape = "scalar"
+    elif ext in (".csv", ".tsv"):
+        sep = "\t" if ext == ".tsv" else ","
+        rows = text.splitlines()
+        header = rows[0].split(sep) if rows else []
+        shown = ", ".join(h.strip() for h in header[:8])
+        shape = f"cols: {shown}" + (" …" if len(header) > 8 else "") + f"; {max(0, len(rows) - 1)} rows"
+    else:  # md / txt / yaml
+        head = ""
+        for line in text.splitlines():
+            s = line.strip()
+            if s:
+                head = _truncate(s.lstrip("#").strip(), 50)
+                break
+        shape = f"{n_lines} lines" + (f" — {head}" if head else "")
+    return shape, True
+
+
 def _attribute_artifacts(agents: list[_AgentDigest], work_dir: Path) -> None:
     """Fill each agent's ``artifacts`` list: link every file to the tool call
     that produced it, and drop untouched inherited copies.
@@ -514,13 +563,29 @@ def _attribute_artifacts(agents: list[_AgentDigest], work_dir: Path) -> None:
             except OSError:
                 size = None
             arts.append({"path": rel, "size": size,
-                         "provenance": _provenance(f, name, a), "note": note})
+                         "provenance": _provenance(f, name, a), "note": note,
+                         "_file": f})
         # Files written via tool but no longer on disk (renamed/deleted) keep
         # their provenance so the story isn't lost.
         for nm, chain in sorted(a.writes.items()):
             if nm not in seen:
                 arts.append({"path": nm, "size": None,
-                             "provenance": ", ".join(chain), "note": None})
+                             "provenance": ", ".join(chain), "note": None,
+                             "_file": None})
+        # Assign a-ids in render order; give small text artifacts a shape hint
+        # and a retrievable index entry (digest-get reads the file, sliced).
+        for i, art in enumerate(arts, start=1):
+            f = art.pop("_file")
+            if f is None:
+                art["shape"] = None
+                continue
+            shape, retrievable = _artifact_shape(f, art["size"])
+            art["shape"] = shape
+            if retrievable:
+                a.index[f"{a.qual}/a{i}"] = {
+                    "log_file": _rel(f, work_dir), "line_no": 1,
+                    "event_type": "artifact",
+                }
         a.artifacts = arts
 
 
@@ -643,6 +708,8 @@ def _render_agent(a: _AgentDigest, brief: bool) -> list[str]:
             bits: list[str] = []
             if art["size"] is not None:
                 bits.append(_human_size(art["size"]))
+            if art.get("shape"):
+                bits.append(art["shape"])
             if art.get("provenance"):
                 bits.append(f"← {art['provenance']}")
             if art.get("note"):

--- a/dlab/session_digest.py
+++ b/dlab/session_digest.py
@@ -1,0 +1,454 @@
+"""
+Deterministic session digest for the notebook composer (issue #85).
+
+Builds an LLM-facing map of a completed dlab work directory on top of
+``opencode_logparser`` — no LLM, no agent, pure mechanical extraction — and a
+thin machine index so an agent can retrieve any element by ID via the
+``digest-get`` tool. Written into the work dir before the composer runs:
+
+    _digest/digest.md     — the map (per-agent sections, workflow tree)
+    _digest/index.json    — { "<agent>/<id>": {log_file, line_no, event_type} }
+
+ID scheme (spec §7.1): one shared counter per agent — ``t07`` (tool call),
+``x08`` (text/reasoning), ``t09`` — the number IS the timeline. Artifacts get
+``a1..`` (display only, not indexed); the differentiating prompt gets ``p0``
+(indexed → the dlab_start line). Fully-qualified IDs are ``<agent>/<id>`` where
+``<agent>`` is ``main`` or e.g. ``poet.r1.i2`` / ``poet.r1.cons``.
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+from dlab.opencode_logparser import (
+    LogEvent,
+    ms_to_datetime,
+    parse_line,
+    get_step_cost,
+    get_text,
+    get_tool_error,
+    get_tool_input,
+    get_tool_name,
+    get_tool_status,
+)
+
+DIGEST_DIR = "_digest"
+
+# The in-container retrieval tool (spec §7.2), shipped as package data and
+# materialized into the composer's .opencode/tools/ by the composer step.
+DIGEST_GET_SOURCE: str = files("dlab.js").joinpath("digest-get.ts").read_text()
+
+_EXCERPT_LEN = 160
+_TASK_LEN = 240
+# Work-dir entries that are session internals, not agent artifacts.
+_ROOT_SKIP = {
+    "_opencode_logs", "_digest", "_docker", "_hooks", ".opencode",
+    "parallel", "data", ".state.json", ".git",
+}
+
+
+@dataclass
+class _IndexedEvent:
+    line_no: int
+    event: LogEvent
+
+
+@dataclass
+class _AgentDigest:
+    """Everything computed for one agent's ``###`` section."""
+    qual: str                                   # e.g. "main", "poet.r1.i2"
+    role: str                                   # "orchestrator" | agent name
+    heading: str                                # human heading suffix
+    log_rel: str                                # log path relative to work_dir
+    workdir_rel: str | None                     # instance workdir, if any
+    model: str | None
+    duration_s: float
+    cost: float
+    tool_count: int
+    task_text: str | None                       # differentiating prompt (p0)
+    task_line: int | None
+    tool_counter: Counter                       # tool name -> n
+    script_runs: list[dict[str, Any]]           # bash calls
+    writes: dict[str, list[str]]                # file -> ["written t6", ...]
+    excerpts: list[tuple[str, str]]             # (id, truncated text)
+    index: dict[str, dict[str, Any]]            # local ids -> pointer
+    summary_ok: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Parsing with line numbers
+# ---------------------------------------------------------------------------
+
+
+def _iter_indexed(log_path: Path) -> list[_IndexedEvent]:
+    """Every parseable line of a log as (1-based line number, event)."""
+    out: list[_IndexedEvent] = []
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for i, line in enumerate(text.splitlines(), start=1):
+        ev = parse_line(line)
+        if ev is not None:
+            out.append(_IndexedEvent(i, ev))
+    return out
+
+
+def _differentiating_prompt(full_prompt: str) -> str:
+    """Strip the injected subagent-context preamble and the shared suffix so
+    the Task field shows what makes this instance distinct."""
+    marker = "CRITICAL OUTPUT RULES"
+    text = full_prompt
+    # Drop the injected "IMPORTANT CONTEXT ... CRITICAL OUTPUT RULES ..." block
+    # that parallel-agents.ts prepends; the real task follows it.
+    if "IMPORTANT CONTEXT" in text and marker in text:
+        # The suffix prompt is appended after the task; the task is the middle.
+        after = text.split(marker, 1)[1]
+        # everything after the rules block's blank-line separator
+        parts = after.split("\n\n", 1)
+        text = parts[1] if len(parts) > 1 else after
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Per-agent digest
+# ---------------------------------------------------------------------------
+
+
+def _digest_agent(qual: str, role: str, heading: str, log_path: Path,
+                  work_dir: Path, workdir_rel: str | None,
+                  summary_ok: bool = True) -> _AgentDigest:
+    indexed = _iter_indexed(log_path)
+    log_rel = _rel(log_path, work_dir)
+
+    counter = 0
+    cost = 0.0
+    tool_count = 0
+    model: str | None = None
+    task_text: str | None = None
+    task_line: int | None = None
+    tool_counter: Counter = Counter()
+    script_runs: list[dict[str, Any]] = []
+    writes: dict[str, list[str]] = {}
+    excerpts: list[tuple[str, str]] = []
+    index: dict[str, dict[str, Any]] = {}
+
+    for ie in indexed:
+        ev = ie.event
+        et = ev.event_type
+        if et == "dlab_start":
+            model = ev.raw.get("model") or ev.part.get("model")
+            prompt = ev.raw.get("prompt") or ev.part.get("prompt") or ""
+            if prompt:
+                task_text = _differentiating_prompt(prompt)
+                task_line = ie.line_no
+                index[f"{qual}/p0"] = {
+                    "log_file": log_rel, "line_no": ie.line_no,
+                    "event_type": "dlab_start",
+                }
+        elif et == "step_finish":
+            cost += get_step_cost(ev) or 0.0
+        elif et == "tool_use":
+            counter += 1
+            tid = f"t{counter}"
+            index[f"{qual}/{tid}"] = {
+                "log_file": log_rel, "line_no": ie.line_no,
+                "event_type": "tool_use",
+            }
+            tool_count += 1
+            name = get_tool_name(ev) or "?"
+            tool_counter[name] += 1
+            if name == "bash":
+                script_runs.append(_script_run(tid, ev))
+            if name in ("write", "edit"):
+                fp = (get_tool_input(ev) or {}).get("filePath")
+                if fp:
+                    verb = "written" if name == "write" else "edited"
+                    writes.setdefault(_basename(fp), []).append(f"{verb} {tid}")
+        elif et == "text":
+            counter += 1
+            xid = f"x{counter}"
+            index[f"{qual}/{xid}"] = {
+                "log_file": log_rel, "line_no": ie.line_no,
+                "event_type": "text",
+            }
+            txt = (get_text(ev) or "").strip()
+            if txt:
+                excerpts.append((xid, _truncate(txt, _EXCERPT_LEN)))
+
+    ts = [ie.event.timestamp for ie in indexed if ie.event.timestamp]
+    duration_s = (max(ts) - min(ts)) / 1000 if len(ts) > 1 else 0.0
+
+    return _AgentDigest(
+        qual=qual, role=role, heading=heading, log_rel=log_rel,
+        workdir_rel=workdir_rel, model=model, duration_s=duration_s, cost=cost,
+        tool_count=tool_count, task_text=task_text, task_line=task_line,
+        tool_counter=tool_counter, script_runs=script_runs, writes=writes,
+        excerpts=excerpts, index=index, summary_ok=summary_ok,
+    )
+
+
+def _script_run(tid: str, ev: LogEvent) -> dict[str, Any]:
+    inp = get_tool_input(ev) or {}
+    status = get_tool_status(ev)
+    ok = status == "completed" and not get_tool_error(ev)
+    from dlab.opencode_logparser import get_tool_output
+    out = get_tool_output(ev) or ""
+    err = get_tool_error(ev) or ""
+    stream = err if err else out
+    n_lines = len(stream.splitlines()) if stream else 0
+    which = "stderr" if err else "stdout"
+    tail = ""
+    if stream:
+        last = stream.splitlines()[-1].strip()
+        tail = _truncate(last, 80)
+    start, end = None, None
+    tt = ev.part.get("state", {}).get("time", {}) if isinstance(ev.part, dict) else {}
+    if isinstance(tt, dict):
+        start, end = tt.get("start"), tt.get("end")
+    dur = (end - start) / 1000 if start and end else None
+    return {
+        "id": tid,
+        "cmd": inp.get("command") or inp.get("description") or "",
+        "ok": ok, "duration_s": dur, "stream": which,
+        "n_lines": n_lines, "tail": tail,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Graph traversal → agents
+# ---------------------------------------------------------------------------
+
+
+def _collect_agents(work_dir: Path) -> list[_AgentDigest]:
+    logs_dir = work_dir / "_opencode_logs"
+    agents: list[_AgentDigest] = []
+
+    main_log = logs_dir / "main.log"
+    if main_log.exists():
+        agents.append(_digest_agent(
+            "main", "orchestrator", "orchestrator", main_log, work_dir, None,
+        ))
+
+    # Group parallel run dirs by agent name; rank timestamps → round number.
+    run_dirs = sorted(d for d in logs_dir.glob("*-parallel-run-*") if d.is_dir())
+    by_agent: dict[str, list[tuple[str, Path]]] = {}
+    for d in run_dirs:
+        agent, _, ts = d.name.rpartition("-parallel-run-")
+        by_agent.setdefault(agent, []).append((ts, d))
+
+    for agent, runs in by_agent.items():
+        runs.sort(key=lambda r: r[0])
+        for round_idx, (ts, d) in enumerate(runs, start=1):
+            retry = f" (retry round {round_idx})" if len(runs) > 1 else ""
+            for inst_log in sorted(d.glob("instance-*.log")):
+                n = inst_log.stem.split("-")[-1]
+                qual = f"{agent}.r{round_idx}.i{n}"
+                inst_work = f"parallel/run-{ts}/instance-{n}"
+                summary_ok = (work_dir / inst_work / "summary.md").exists()
+                agents.append(_digest_agent(
+                    qual, agent, f"{agent}, instance {n}{retry}",
+                    inst_log, work_dir, inst_work, summary_ok,
+                ))
+            cons_log = d / "consolidator.log"
+            if cons_log.exists():
+                qual = f"{agent}.r{round_idx}.cons"
+                agents.append(_digest_agent(
+                    qual, agent, f"{agent} consolidator{retry}",
+                    cons_log, work_dir, f"parallel/run-{ts}", True,
+                ))
+    return agents
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def build_digest(work_dir: str | Path, *, brief: bool = False) -> tuple[str, dict[str, dict[str, Any]]]:
+    """
+    Build the digest markdown and index for a completed work directory.
+
+    Parameters
+    ----------
+    work_dir : str | Path
+        Completed session work directory.
+    brief : bool
+        If True, collapse the full tool tables to one-line counts.
+
+    Returns
+    -------
+    tuple[str, dict]
+        (digest_markdown, index) — index maps "<agent>/<id>" to a pointer
+        dict {log_file, line_no, event_type}.
+    """
+    work_dir = Path(work_dir)
+    agents = _collect_agents(work_dir)
+    index: dict[str, dict[str, Any]] = {}
+    for a in agents:
+        index.update(a.index)
+
+    total_cost = sum(a.cost for a in agents)
+    orch = next((a for a in agents if a.qual == "main"), None)
+
+    lines: list[str] = [f"# Session digest: {work_dir.name}", ""]
+    if orch:
+        lines.append(
+            f"- orchestrator: {orch.model or 'unknown'} | "
+            f"{orch.duration_s:.0f}s | ${orch.cost:.3f}"
+        )
+    lines.append(f"- agents: {len(agents)} | total cost: ${total_cost:.3f}")
+    lines.append("")
+
+    lines += _render_tree(work_dir, agents)
+    lines.append("")
+    lines += _render_root_artifacts(work_dir)
+
+    for a in agents:
+        lines.append("")
+        lines += _render_agent(a, brief)
+
+    return "\n".join(lines) + "\n", index
+
+
+def _render_tree(work_dir: Path, agents: list[_AgentDigest]) -> list[str]:
+    lines = ["## Workflow tree", "", "- **main** (orchestrator)"]
+    # group non-main agents by their run (agent.rN)
+    groups: dict[str, list[_AgentDigest]] = {}
+    for a in agents:
+        if a.qual == "main":
+            continue
+        run_key = a.qual.rsplit(".", 1)[0]  # agent.rN
+        groups.setdefault(run_key, []).append(a)
+    for run_key, members in groups.items():
+        agent = run_key.split(".")[0]
+        lines.append(f"  - parallel fan-out: **{agent}** ({run_key})")
+        for a in members:
+            if a.qual.endswith(".cons"):
+                lines.append(f"    - {a.qual}: {a.duration_s:.0f}s, ${a.cost:.3f} — consolidator")
+            else:
+                status = "summary written" if a.summary_ok else "NO summary.md (treat as failed)"
+                lines.append(
+                    f"    - {a.qual}: {a.duration_s:.0f}s, ${a.cost:.3f}, "
+                    f"{a.tool_count} tool calls — {status}"
+                )
+                lines.append(f"      - log: `{a.log_rel}` | workdir: `{a.workdir_rel}/`")
+    return lines
+
+
+def _render_root_artifacts(work_dir: Path) -> list[str]:
+    lines = ["## Final artifacts (workdir root)", ""]
+    found = False
+    for f in sorted(work_dir.iterdir()):
+        if f.name in _ROOT_SKIP or f.name.startswith("."):
+            continue
+        if f.is_file():
+            lines.append(f"- `{f.name}` ({_human_size(f.stat().st_size)})")
+            found = True
+    if not found:
+        lines.append("- (none)")
+    return lines
+
+
+def _render_agent(a: _AgentDigest, brief: bool) -> list[str]:
+    lines = [f"### {a.qual} — {a.heading}"]
+    lines.append(
+        f"model: {a.model or 'unknown'} | {a.duration_s:.0f}s | "
+        f"${a.cost:.3f} | {a.tool_count} tool calls"
+    )
+    if a.workdir_rel:
+        lines.append(f"workdir: {a.workdir_rel}/")
+    lines.append("")
+
+    if a.task_text:
+        lines.append(
+            f'**Task** [p0]: "{_truncate(a.task_text, _TASK_LEN)}" '
+            f"(full prompt via digest-get {a.qual}/p0)"
+        )
+        lines.append("")
+
+    if a.writes:
+        lines.append("**Artifacts**")
+        for i, (fname, chain) in enumerate(sorted(a.writes.items()), start=1):
+            lines.append(f"- [a{i}] {fname} ({', '.join(chain)})")
+        lines.append("")
+
+    if a.script_runs:
+        lines.append("**Script runs**")
+        for s in a.script_runs:
+            mark = "✓" if s["ok"] else "✗ error"
+            dur = f"{s['duration_s']:.0f}s" if s["duration_s"] is not None else ""
+            detail = f"{s['stream']} {s['n_lines']} lines" if s["n_lines"] else "no output"
+            if s["tail"]:
+                detail += f" — {s['tail']}"
+            lines.append(f"- [{s['id']}] bash `{_truncate(s['cmd'], 60)}`  {mark}  {dur}  ({detail})")
+        lines.append("")
+
+    if brief:
+        counts = ", ".join(f"{k}×{v}" for k, v in a.tool_counter.most_common())
+        if counts:
+            lines.append(f"**Tool calls**: {counts}")
+    else:
+        other = {k: v for k, v in a.tool_counter.items() if k not in ("bash",)}
+        if other:
+            counts = ", ".join(f"{k}×{v}" for k, v in Counter(other).most_common())
+            lines.append(f"**Other tool calls**: {counts}")
+
+    if a.excerpts:
+        lines.append("**Reasoning excerpts**")
+        for xid, txt in a.excerpts:
+            lines.append(f"- [{xid}] \"{txt}\"")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_digest(work_dir: str | Path, *, brief: bool = False) -> Path:
+    """
+    Write ``_digest/digest.md`` and ``_digest/index.json`` into ``work_dir``.
+
+    Returns the path to the digest directory.
+    """
+    work_dir = Path(work_dir)
+    md, index = build_digest(work_dir, brief=brief)
+    out_dir = work_dir / DIGEST_DIR
+    out_dir.mkdir(exist_ok=True)
+    (out_dir / "digest.md").write_text(md, encoding="utf-8")
+    (out_dir / "index.json").write_text(json.dumps(index, indent=2), encoding="utf-8")
+    return out_dir
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _rel(path: Path, base: Path) -> str:
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return str(path)
+
+
+def _basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def _truncate(text: str, n: int) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= n else text[: n - 1] + "…"
+
+
+def _human_size(n: int) -> str:
+    if n >= 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f}MB"
+    if n >= 1024:
+        return f"{n / 1024:.1f}KB"
+    return f"{n}B"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -304,6 +304,31 @@ dlab view WORK_DIR [--port PORT] [--no-open] [--export FILE]
 
 ---
 
+## digest
+
+Build a deterministic session digest — an LLM-facing map of a completed run (per-agent sections, workflow tree, artifact write-chains, script runs, reasoning excerpts). This is the same digest the notebook composer consumes; the command exposes it for inspection and for materializing the `_digest/` plumbing by hand. No LLM, no execution — pure extraction on top of `opencode_logparser`.
+
+```bash
+dlab digest [WORK_DIR] [--brief] [--write]
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `WORK_DIR` | Current directory (if it contains `_opencode_logs`) | Path to session work directory |
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--brief` | — | Collapse the per-agent tool tables to one-line counts |
+| `--write`, `-w` | — | Write `_digest/digest.md` and `_digest/index.json` into the work dir instead of printing the digest to stdout |
+
+Without `--write`, the digest markdown is printed to stdout (pipe-friendly: `dlab digest ./run | less`). The machine index (`index.json`) is only emitted in `--write` mode, since it is only meaningful as a file alongside the markdown (it is what the `digest-get` tool reads).
+
+---
+
 ## Help
 
 ```bash
@@ -313,5 +338,6 @@ dlab create-parallel-agent --help
 dlab connect --help
 dlab timeline --help
 dlab view --help
+dlab digest --help
 dlab install --help
 ```

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -1,11 +1,14 @@
 """Tests for the deterministic session digest + digest-get tool (issue #85)."""
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from dlab.cli import app, cmd_digest
 from dlab.session_digest import (
     DIGEST_GET_SOURCE,
     build_digest,
@@ -177,3 +180,63 @@ console.log("ok");
         js.write_text(driver)
         r = subprocess.run(["node", str(js)], capture_output=True, text=True, timeout=15)
         assert r.returncode == 0, r.stderr
+
+
+class TestDigestCommand:
+    """The `dlab digest` CLI subcommand (thin wrapper over build/generate)."""
+
+    def test_stdout_default(self, capsys: pytest.CaptureFixture) -> None:
+        rc = cmd_digest(str(FIXTURE))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert out.startswith("# Session digest: sample_session")
+        assert "### main — orchestrator" in out
+
+    def test_write_materializes_pair(self, tmp_path: Path,
+                                     capsys: pytest.CaptureFixture) -> None:
+        run = tmp_path / "run"
+        shutil.copytree(FIXTURE, run)
+        rc = cmd_digest(str(run), write=True)
+        assert rc == 0
+        digest_md = run / "_digest" / "digest.md"
+        index_json = run / "_digest" / "index.json"
+        assert digest_md.is_file() and index_json.is_file()
+        # stdout reports the written paths, not the digest body.
+        out = capsys.readouterr().out
+        assert "digest.md" in out and "index.json" in out
+        assert "# Session digest" not in out
+        index = json.loads(index_json.read_text())
+        assert any(k.startswith("main/") for k in index)
+
+    def test_brief_is_shorter_than_full(self) -> None:
+        full, _ = build_digest(FIXTURE, brief=False)
+        brief, _ = build_digest(FIXTURE, brief=True)
+        assert len(brief) <= len(full)
+
+    def test_cwd_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+                          capsys: pytest.CaptureFixture) -> None:
+        run = tmp_path / "run"
+        shutil.copytree(FIXTURE, run)
+        monkeypatch.chdir(run)
+        rc = cmd_digest(None)
+        assert rc == 0
+        assert "# Session digest" in capsys.readouterr().out
+
+    def test_missing_logs_errors(self, tmp_path: Path,
+                                 capsys: pytest.CaptureFixture) -> None:
+        rc = cmd_digest(str(tmp_path))
+        assert rc == 1
+        assert "_opencode_logs" in capsys.readouterr().err
+
+    def test_no_arg_without_logs_errors(self, tmp_path: Path,
+                                        monkeypatch: pytest.MonkeyPatch,
+                                        capsys: pytest.CaptureFixture) -> None:
+        monkeypatch.chdir(tmp_path)
+        rc = cmd_digest(None)
+        assert rc == 1
+        assert "No work directory specified" in capsys.readouterr().err
+
+    def test_command_is_registered(self) -> None:
+        result = CliRunner().invoke(app, ["digest", "--help"])
+        assert result.exit_code == 0
+        assert "session digest" in result.output.lower()

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -164,7 +164,9 @@ class TestDigestRichFeatures:
         ]) + "\n")
         md, _ = build_digest(wd)
         assert f"`{long_cmd}`" in md
-        assert "…" not in md.split("**Script runs**", 1)[1].split("\n")[1]
+        cmd_row = next(l for l in md.splitlines()
+                       if "prepare_data.py" in l and "bash" in l)
+        assert "…" not in cmd_row  # command not truncated
 
     def test_brief_collapses_tool_tables(self, tmp_path: Path) -> None:
         wd = _rich_workdir(tmp_path)
@@ -300,6 +302,79 @@ class TestArtifactAttribution:
         assert "poem.txt" not in cons  # sibling's file, not the consolidator's
 
 
+class TestRawTextAndToolCalls:
+    def test_raw_text_gets_rid_range_and_maps_to_call(self, tmp_path: Path) -> None:
+        wd = tmp_path / "r"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1000, model="m", agent="main"),
+            _line("tool_use", 1100, part={"tool": "bash", "state": {
+                "status": "completed", "input": {"command": "python fit.py"},
+                "time": {"start": 1100, "end": 5100}}}),
+            "sampling chain 1 complete",
+            "sampling chain 2 complete",
+            "[STDERR] Traceback (most recent call last):",
+            "[STDERR] ValueError: boom",
+        ]) + "\n")
+        md, index = build_digest(wd)
+        # the raw_text block is one r-id, indexed as a line RANGE
+        rids = [k for k in index if k.startswith("main/r")]
+        assert len(rids) == 1
+        entry = index[rids[0]]
+        assert entry["event_type"] == "raw_text"
+        assert entry["line_end"] > entry["line_no"]
+        # the bash call row points at it, and a [STDERR] line marks it stderr
+        call_row = next(l for l in md.splitlines() if "python fit.py" in l)
+        assert "→ r" in call_row
+        assert "stderr" in call_row
+
+    def test_shared_counter_includes_raw_text(self, tmp_path: Path) -> None:
+        # r-ids share the per-agent counter with t/x (the numbering is time).
+        wd = tmp_path / "r"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1000, model="m", agent="main"),
+            _line("tool_use", 1100, part={"tool": "bash", "state": {
+                "status": "completed", "input": {"command": "x"},
+                "time": {"start": 1100, "end": 1200}}}),
+            "some stdout",
+            _line("text", 1300, part={"type": "text", "text": "done"}),
+        ]) + "\n")
+        _, index = build_digest(wd)
+        ids = {k.split("/")[1] for k in index if k != "main/p0"}
+        # bash=t1, its raw_text=r2, the text=x3 — consecutive on one counter
+        assert {"t1", "r2", "x3"} <= ids
+
+    def test_from_tool_call_provenance_via_mtime(self, tmp_path: Path) -> None:
+        import os
+        wd = tmp_path / "m"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1000, model="m", agent="main"),
+            _line("tool_use", 2000, part={"tool": "fit-model-modal", "state": {
+                "status": "completed", "input": {},
+                "time": {"start": 2000, "end": 8000}}}),
+        ]) + "\n")
+        f = wd / "fitted_model.nc"
+        f.write_text("x" * 100)
+        os.utime(f, (5.0, 5.0))  # mtime 5000ms, inside the call's [2000,8000]
+        md, _ = build_digest(wd)
+        row = next(l for l in md.splitlines()
+                   if "fitted_model.nc" in l and l.strip().startswith("- [a"))
+        assert "← from t1 (fit-model-modal)" in row
+
+    def test_custom_tools_labeled_not_just_bash(self, tmp_path: Path) -> None:
+        wd = _rich_workdir(tmp_path)  # bash + write + edit exist here
+        md, _ = build_digest(wd)
+        section = next(s for s in md.split("### ") if s.startswith("modeler.r1.i1"))
+        assert "**Tool calls**" in section
+        assert "write fit_model.py" in section  # write is a labeled row now
+        assert "**Navigational**" not in section or "read" in section
+
+
 def _have_node() -> bool:
     try:
         subprocess.run(["node", "--version"], capture_output=True, timeout=5)
@@ -313,6 +388,12 @@ class TestDigestGetTool:
         assert "_digest" in DIGEST_GET_SOURCE and "index.json" in DIGEST_GET_SOURCE
         assert "function renderPayload" in DIGEST_GET_SOURCE
         assert "function sliceText" in DIGEST_GET_SOURCE
+
+    def test_source_handles_raw_text_and_line_ranges(self) -> None:
+        # r-ids: reads a line range (line_no..line_end) and strips [STDERR].
+        assert "line_end" in DIGEST_GET_SOURCE
+        assert 'event_type === "raw_text"' in DIGEST_GET_SOURCE
+        assert "[STDERR]" in DIGEST_GET_SOURCE
 
     def test_runtime_render_and_slice(self, tmp_path: Path) -> None:
         if not _have_node():

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -1,0 +1,179 @@
+"""Tests for the deterministic session digest + digest-get tool (issue #85)."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dlab.session_digest import (
+    DIGEST_GET_SOURCE,
+    build_digest,
+    generate_digest,
+    _differentiating_prompt,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_session"
+
+
+def _line(event_type: str, ts: int, **body) -> str:
+    return json.dumps({"type": event_type, "timestamp": ts, **body})
+
+
+def _rich_workdir(tmp_path: Path) -> Path:
+    """A synthetic run exercising Task, script runs (pass+fail), and writes."""
+    wd = tmp_path / "rich"
+    logs = wd / "_opencode_logs"
+    run = logs / "modeler-parallel-run-1700000000000"
+    run.mkdir(parents=True)
+    inst_work = wd / "parallel" / "run-1700000000000" / "instance-1"
+    inst_work.mkdir(parents=True)
+    (inst_work / "summary.md").write_text("done")
+
+    (logs / "main.log").write_text("\n".join([
+        _line("dlab_start", 1700000000000, model="anthropic/claude-sonnet-4-5", agent="main"),
+        _line("text", 1700000000100, part={"type": "text", "text": "Spawning modelers."}),
+        _line("tool_use", 1700000000200, part={
+            "tool": "parallel-agents", "state": {
+                "status": "completed",
+                "input": {"agent": "modeler", "prompts": ["fit"]},
+                "time": {"start": 1700000000200, "end": 1700000005000},
+            }}),
+        _line("step_finish", 1700000006000, part={"type": "step-finish", "reason": "stop", "cost": 0.02}),
+    ]) + "\n")
+
+    # instance-1: dlab_start w/ injected-context prompt, a failing then passing
+    # bash, a write, and reasoning text.
+    injected = (
+        "IMPORTANT CONTEXT: You are running as a parallel subagent.\n\n"
+        "CRITICAL OUTPUT RULES:\n- write summary.md\n\n"
+        "Fit a geometric-adstock MMM with saturating priors on /workspace/data."
+    )
+    (run / "instance-1.log").write_text("\n".join([
+        _line("dlab_start", 1700000000300, model="anthropic/claude-sonnet-4-5",
+              agent="modeler", prompt=injected),
+        _line("text", 1700000000400, part={"type": "text", "text": "Writing fit_model.py."}),
+        _line("tool_use", 1700000000500, part={
+            "tool": "write", "state": {"status": "completed",
+                                        "input": {"filePath": "/workspace/parallel/x/instance-1/fit_model.py"},
+                                        "output": "Wrote file."}}),
+        _line("tool_use", 1700000000600, part={
+            "tool": "bash", "state": {"status": "completed",
+                                      "input": {"command": "python fit_model.py"},
+                                      "error": "Traceback...\nKeyError: 'is_valid'",
+                                      "time": {"start": 1700000000600, "end": 1700000000900}}}),
+        _line("text", 1700000001000, part={"type": "text", "text": "Fixing the key error, rerunning."}),
+        _line("tool_use", 1700000001100, part={
+            "tool": "bash", "state": {"status": "completed",
+                                      "input": {"command": "python fit_model.py"},
+                                      "output": "sampling...\ndone\nr-hat ok",
+                                      "time": {"start": 1700000001100, "end": 1700000004100}}}),
+        _line("step_finish", 1700000005000, part={"type": "step-finish", "reason": "stop", "cost": 0.05}),
+    ]) + "\n")
+    (wd / "report.md").write_text("# report")
+    return wd
+
+
+class TestDiffPrompt:
+    def test_strips_injected_context(self) -> None:
+        p = ("IMPORTANT CONTEXT: blah\n\nCRITICAL OUTPUT RULES:\n- x\n\n"
+             "The real task here.")
+        assert _differentiating_prompt(p) == "The real task here."
+
+    def test_plain_prompt_untouched(self) -> None:
+        assert _differentiating_prompt("just do X") == "just do X"
+
+
+class TestDigestAgainstFixture:
+    def test_structure(self) -> None:
+        md, index = build_digest(FIXTURE)
+        assert "# Session digest: sample_session" in md
+        assert "## Workflow tree" in md
+        # one section per agent: main + 2 instances + consolidator
+        assert md.count("\n### ") == 4
+        assert "### main — orchestrator" in md
+        assert "poet.r1.i1" in md and "poet.r1.cons" in md
+
+    def test_shared_event_counter_and_index(self) -> None:
+        md, index = build_digest(FIXTURE)
+        # main: text(x1), tool(t2), text(x3) — the counter is shared.
+        assert index["main/x1"]["event_type"] == "text"
+        assert index["main/t2"]["event_type"] == "tool_use"
+        assert index["main/x3"]["event_type"] == "text"
+        # the pointer's line actually contains that event
+        entry = index["main/t2"]
+        line = (FIXTURE / entry["log_file"]).read_text().splitlines()[entry["line_no"] - 1]
+        assert '"tool": "parallel-agents"' in line
+
+
+class TestDigestRichFeatures:
+    def test_task_artifacts_scripts(self, tmp_path: Path) -> None:
+        wd = _rich_workdir(tmp_path)
+        md, index = build_digest(wd)
+        # Task field (differentiating prompt) + its p0 index entry
+        assert "geometric-adstock MMM" in md
+        assert "modeler.r1.i1/p0" in index
+        # write chain
+        assert "fit_model.py (written t" in md
+        # script runs: one failed, one ok
+        assert "✗ error" in md
+        assert md.count("bash `python fit_model.py`") == 2
+        # failed bash surfaces the stderr tail
+        assert "KeyError" in md
+
+    def test_brief_collapses_tool_tables(self, tmp_path: Path) -> None:
+        wd = _rich_workdir(tmp_path)
+        full, _ = build_digest(wd)
+        brief, _ = build_digest(wd, brief=True)
+        assert "**Tool calls**:" in brief
+        assert len(brief) < len(full)
+
+    def test_generate_writes_files(self, tmp_path: Path) -> None:
+        wd = _rich_workdir(tmp_path)
+        out = generate_digest(wd)
+        assert (out / "digest.md").exists()
+        assert (out / "index.json").exists()
+        idx = json.loads((out / "index.json").read_text())
+        assert any(k.endswith("/p0") for k in idx)
+
+
+def _have_node() -> bool:
+    try:
+        subprocess.run(["node", "--version"], capture_output=True, timeout=5)
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+class TestDigestGetTool:
+    def test_source_reads_index_and_slices(self) -> None:
+        assert "_digest" in DIGEST_GET_SOURCE and "index.json" in DIGEST_GET_SOURCE
+        assert "function renderPayload" in DIGEST_GET_SOURCE
+        assert "function sliceText" in DIGEST_GET_SOURCE
+
+    def test_runtime_render_and_slice(self, tmp_path: Path) -> None:
+        if not _have_node():
+            pytest.skip("node not available")
+        # Extract the two pure helpers from the actual source, strip TS types.
+        import re
+        src = DIGEST_GET_SOURCE
+        helpers = src[src.index("function renderPayload"):]
+        helpers = re.sub(r"\?:\s*(string|number|any)", "", helpers)  # optional params
+        helpers = re.sub(r":\s*(string|number|any)", "", helpers)    # params + returns
+        tool_line = json.dumps({"type": "tool_use", "part": {"tool": "bash", "state": {
+            "input": {"command": "python x.py"},
+            "output": "l1\nl2\nl3\nl4\nl5"}}})
+        driver = f"""
+{helpers}
+const obj = {tool_line};
+const rendered = renderPayload(obj, "tool_use");
+if (!rendered.includes("python x.py")) process.exit(1);
+if (!rendered.includes("l5")) process.exit(1);
+const tail = sliceText(rendered, undefined, 2, undefined);
+if (tail.split("\\n").length !== 2 || !tail.includes("l5")) process.exit(2);
+console.log("ok");
+"""
+        js = tmp_path / "d.js"
+        js.write_text(driver)
+        r = subprocess.run(["node", str(js)], capture_output=True, text=True, timeout=15)
+        assert r.returncode == 0, r.stderr

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -488,6 +488,50 @@ class TestArtifactRetrieval:
         assert 'event_type === "artifact"' in DIGEST_GET_SOURCE
 
 
+class TestCustomToolSource:
+    """A custom tool (has a .opencode/tools/<name>.ts) gets its source bundled
+    into its tN retrieval, so the composer can reproduce what it ran."""
+
+    def _workdir(self, tmp_path: Path) -> Path:
+        wd = tmp_path / "w"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        tools = wd / ".opencode" / "tools"
+        tools.mkdir(parents=True)
+        (tools / "analyze-thing.ts").write_text(
+            "// runs: python -m mypkg.analyze\nexport default 1\n")
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1000, model="m", agent="main"),
+            _line("tool_use", 1100, part={"tool": "analyze-thing", "state": {
+                "status": "completed", "input": {"model_path": "m.nc"},
+                "time": {"start": 1100, "end": 1200}}}),
+            _line("tool_use", 1300, part={"tool": "bash", "state": {
+                "status": "completed", "input": {"command": "ls"},
+                "time": {"start": 1300, "end": 1310}}}),
+        ]) + "\n")
+        return wd
+
+    def test_custom_tool_indexed_with_source_builtin_not(self, tmp_path: Path) -> None:
+        wd = self._workdir(tmp_path)
+        _, index = build_digest(wd)
+        custom = {k: v for k, v in index.items()
+                  if v["event_type"] == "tool_use" and v.get("tool_source")}
+        assert len(custom) == 1
+        assert list(custom.values())[0]["tool_source"] == ".opencode/tools/analyze-thing.ts"
+        # the bash call is built-in — no tool_source
+        assert any(v["event_type"] == "tool_use" and "tool_source" not in v
+                   for v in index.values())
+
+    def test_custom_tool_row_flagged(self, tmp_path: Path) -> None:
+        md, _ = build_digest(self._workdir(tmp_path))
+        assert "analyze-thing (custom)" in md
+        assert "bash (custom)" not in md
+
+    def test_digest_get_appends_tool_source(self) -> None:
+        assert "tool_source" in DIGEST_GET_SOURCE
+        assert "the code this tool ran" in DIGEST_GET_SOURCE
+
+
 def _have_node() -> bool:
     try:
         subprocess.run(["node", "--version"], capture_output=True, timeout=5)

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -375,6 +375,73 @@ class TestRawTextAndToolCalls:
         assert "**Navigational**" not in section or "read" in section
 
 
+class TestComposerFeedbackFixes:
+    """Digest tweaks from the composer experiment: input signatures, error
+    tails, LSP-noise stripping, and consolidator failure flagging."""
+
+    def test_custom_tool_shows_input_signature(self, tmp_path: Path) -> None:
+        wd = tmp_path / "c"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1000, model="m", agent="main"),
+            _line("tool_use", 2000, part={"tool": "fit-model-modal", "state": {
+                "status": "completed",
+                "input": {"model_bundle_path": "model_to_fit.pkl",
+                          "output_path": "fitted_model.nc"},
+                "time": {"start": 2000, "end": 3000}}}),
+        ]) + "\n")
+        md, _ = build_digest(wd)
+        row = next(l for l in md.splitlines()
+                   if "fit-model-modal" in l and l.strip().startswith("- [t"))
+        assert "model_bundle_path=model_to_fit.pkl" in row
+        assert "output_path=fitted_model.nc" in row
+
+    def test_error_line_keeps_its_tail(self, tmp_path: Path) -> None:
+        wd = tmp_path / "e"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        errline = ("TypeError: MMMPlotSuite.prior_predictive() got an "
+                   "unexpected keyword argument 'original_scale'")
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1000, model="m", agent="main"),
+            _line("tool_use", 2000, part={"tool": "bash", "state": {
+                "status": "completed", "input": {"command": "python x.py"},
+                "output": errline, "time": {"start": 2000, "end": 2100}}}),
+        ]) + "\n")
+        md, _ = build_digest(wd)
+        row = next(l for l in md.splitlines() if "python x.py" in l)
+        assert "original_scale" in row  # the offending key (line end) survives
+
+    def test_strip_lsp_removes_diagnostics(self) -> None:
+        from dlab.session_digest import _strip_lsp
+        t = ("Edit applied successfully.\n\nLSP errors detected in this file, "
+             "please fix:\n<diagnostics file=\"x.py\">\nERROR [1:2] bad\n</diagnostics>")
+        out = _strip_lsp(t)
+        assert "Edit applied successfully." in out
+        assert "LSP errors" not in out and "diagnostics" not in out
+        assert "ERROR [1:2]" not in out
+
+    def test_digest_get_source_strips_lsp(self) -> None:
+        assert "function stripLsp" in DIGEST_GET_SOURCE
+        assert "diagnostics" in DIGEST_GET_SOURCE
+
+    def test_consolidator_without_output_is_flagged(self, tmp_path: Path) -> None:
+        wd = tmp_path / "c"
+        run = wd / "_opencode_logs" / "poet-parallel-run-500"
+        run.mkdir(parents=True)
+        (run / "instance-1.log").write_text(
+            _line("dlab_start", 500, model="m", agent="poet") + "\n")
+        (run / "consolidator.log").write_text(
+            _line("dlab_start", 900, model="m", agent="consolidator") + "\n")
+        (wd / "parallel" / "run-500" / "instance-1").mkdir(parents=True)
+        md, _ = build_digest(wd)  # no consolidated_summary.md
+        assert "NO consolidated_summary.md (treat as failed)" in md
+        (wd / "parallel" / "run-500" / "consolidated_summary.md").write_text("cmp")
+        md2, _ = build_digest(wd)
+        assert "NO consolidated_summary.md" not in md2
+
+
 def _have_node() -> bool:
     try:
         subprocess.run(["node", "--version"], capture_output=True, timeout=5)

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -32,6 +32,13 @@ def _rich_workdir(tmp_path: Path) -> Path:
     inst_work = wd / "parallel" / "run-1700000000000" / "instance-1"
     inst_work.mkdir(parents=True)
     (inst_work / "summary.md").write_text("done")
+    # fit_model.py is tool-written (below); idata.nc + figures/ are produced by
+    # the SCRIPT and never pass through a tool call — the digest must still list
+    # them by walking the workdir on disk.
+    (inst_work / "fit_model.py").write_text("import pymc as pm\n")
+    (inst_work / "idata.nc").write_text("x" * 2048)
+    (inst_work / "figures").mkdir()
+    (inst_work / "figures" / "adstock.png").write_text("PNG" * 100)
 
     (logs / "main.log").write_text("\n".join([
         _line("dlab_start", 1700000000000, model="anthropic/claude-sonnet-4-5", agent="main"),
@@ -116,13 +123,48 @@ class TestDigestRichFeatures:
         # Task field (differentiating prompt) + its p0 index entry
         assert "geometric-adstock MMM" in md
         assert "modeler.r1.i1/p0" in index
-        # write chain
-        assert "fit_model.py (written t" in md
+        # tool-written file keeps its write chain (and now a size)
+        fit_line = next(l for l in md.splitlines() if "fit_model.py" in l)
+        assert "written t" in fit_line
+        # script-produced outputs (no tool call) are listed by walking the disk
+        assert "idata.nc" in md
+        assert "figures/adstock.png" in md
         # script runs: one failed, one ok
         assert "✗ error" in md
         assert md.count("bash `python fit_model.py`") == 2
         # failed bash surfaces the stderr tail
         assert "KeyError" in md
+
+    def test_script_produced_files_listed(self, tmp_path: Path) -> None:
+        # A file created purely by a bash script (no write/edit tool) must
+        # still appear, with a size and no write chain.
+        wd = _rich_workdir(tmp_path)
+        md, _ = build_digest(wd)
+        nc_line = next(l for l in md.splitlines() if "idata.nc" in l)
+        assert "KB" in nc_line  # has a size
+        assert "written t" not in nc_line  # no fabricated provenance
+
+    def test_script_command_shown_in_full(self, tmp_path: Path) -> None:
+        # A long command must appear verbatim, not truncated to a preview.
+        wd = tmp_path / "run"
+        logs = wd / "_opencode_logs"
+        logs.mkdir(parents=True)
+        long_cmd = (
+            "cd /workspace/parallel/run-1775647475873/instance-1 && "
+            "python prepare_data.py --seed 0 --config full_pipeline.yaml"
+        )
+        (logs / "main.log").write_text("\n".join([
+            _line("dlab_start", 1700000000000, model="m", agent="main"),
+            _line("tool_use", 1700000000100, part={
+                "tool": "bash", "state": {"status": "completed",
+                                          "input": {"command": long_cmd},
+                                          "output": "ok",
+                                          "time": {"start": 1700000000100,
+                                                   "end": 1700000000300}}}),
+        ]) + "\n")
+        md, _ = build_digest(wd)
+        assert f"`{long_cmd}`" in md
+        assert "…" not in md.split("**Script runs**", 1)[1].split("\n")[1]
 
     def test_brief_collapses_tool_tables(self, tmp_path: Path) -> None:
         wd = _rich_workdir(tmp_path)
@@ -138,6 +180,124 @@ class TestDigestRichFeatures:
         assert (out / "index.json").exists()
         idx = json.loads((out / "index.json").read_text())
         assert any(k.endswith("/p0") for k in idx)
+
+
+def _two_phase_workdir(tmp_path: Path) -> Path:
+    """main → phase-1 'prep' (creates data.csv) → phase-2 'model'. Exercises
+    inherited-copy dropping, creator retention, basename collision, and
+    modified-from-inherited. Timestamps are the load-bearing part."""
+    wd = tmp_path / "twophase"
+    logs = wd / "_opencode_logs"
+    logs.mkdir(parents=True)
+    (logs / "main.log").write_text("\n".join([
+        _line("dlab_start", 1000, model="m", agent="main"),
+        _line("tool_use", 1100, part={"tool": "write", "state": {
+            "status": "completed", "input": {"filePath": "/workspace/shared.txt"},
+            "output": "ok"}}),
+        _line("tool_use", 3000, part={"tool": "bash", "state": {
+            "status": "completed", "input": {"command":
+                "cp /workspace/parallel/run-2000/instance-1/data.csv /workspace/data.csv"},
+            "output": "", "time": {"start": 3000, "end": 3001}}}),
+        _line("step_finish", 5000, part={"type": "step-finish", "cost": 0.01}),
+    ]) + "\n")
+    r1 = logs / "prep-parallel-run-2000"
+    r1.mkdir()
+    (r1 / "instance-1.log").write_text("\n".join([
+        _line("dlab_start", 2000, model="m", agent="prep", prompt="make data.csv"),
+        _line("tool_use", 2100, part={"tool": "bash", "state": {
+            "status": "completed", "input": {"command": "python prep.py"},
+            "output": "wrote data.csv", "time": {"start": 2100, "end": 2200}}}),
+        _line("tool_use", 2200, part={"tool": "write", "state": {
+            "status": "completed", "input": {"filePath": "summary.md"}, "output": "ok"}}),
+        _line("step_finish", 2300, part={"type": "step-finish", "cost": 0.01}),
+    ]) + "\n")
+    r2 = logs / "model-parallel-run-4000"
+    r2.mkdir()
+    (r2 / "instance-1.log").write_text("\n".join([
+        _line("dlab_start", 4000, model="m", agent="model", prompt="fit the model"),
+        _line("tool_use", 4100, part={"tool": "write", "state": {
+            "status": "completed", "input": {"filePath": "shared.txt"}, "output": "ok"}}),
+        _line("tool_use", 4200, part={"tool": "bash", "state": {
+            "status": "completed", "input": {"command": "python fit.py"},
+            "output": "wrote out.txt", "time": {"start": 4200, "end": 4300}}}),
+        _line("tool_use", 4300, part={"tool": "write", "state": {
+            "status": "completed", "input": {"filePath": "summary.md"}, "output": "ok"}}),
+        _line("step_finish", 4400, part={"type": "step-finish", "cost": 0.01}),
+    ]) + "\n")
+
+    shared_v1, data = "shared v1\n", "a,b\n1,2\n"
+    (wd / "shared.txt").write_text(shared_v1)
+    (wd / "data.csv").write_text(data)
+    i1 = wd / "parallel" / "run-2000" / "instance-1"
+    i1.mkdir(parents=True)
+    (i1 / "shared.txt").write_text(shared_v1)          # inherited, identical → drop
+    (i1 / "data.csv").write_text(data)                 # prep CREATED it → keep
+    (i1 / "summary.md").write_text("prep summary")     # keep
+    i2 = wd / "parallel" / "run-4000" / "instance-1"
+    i2.mkdir(parents=True)
+    (i2 / "shared.txt").write_text("shared v2 EDITED\n")   # modified-from-inherited → keep+note
+    (i2 / "data.csv").write_text(data)                 # inherited, identical → drop
+    (i2 / "out.txt").write_text("result")              # produced → keep
+    (i2 / "summary.md").write_text("model summary")    # collision, root lacks it → keep, no note
+    return wd
+
+
+def _section(md: str, qual: str) -> str:
+    out, grab = [], False
+    for line in md.splitlines():
+        if line.startswith("### "):
+            grab = line.startswith(f"### {qual} ")
+        elif grab:
+            out.append(line)
+    return "\n".join(out)
+
+
+class TestArtifactAttribution:
+    def test_inherited_identical_copy_dropped(self, tmp_path: Path) -> None:
+        md, _ = build_digest(_two_phase_workdir(tmp_path))
+        prep, model = _section(md, "prep.r1.i1"), _section(md, "model.r1.i1")
+        # prep inherited shared.txt unchanged from main → dropped
+        assert "shared.txt" not in prep
+        # model inherited data.csv unchanged from root seed → dropped
+        assert "data.csv" not in model
+
+    def test_creator_keeps_file_despite_identical_root_copy(self, tmp_path: Path) -> None:
+        md, _ = build_digest(_two_phase_workdir(tmp_path))
+        prep = _section(md, "prep.r1.i1")
+        # root has an identical data.csv (main copied it up) but prep MADE it
+        assert "data.csv" in prep
+
+    def test_modified_inherited_kept_and_flagged(self, tmp_path: Path) -> None:
+        md, _ = build_digest(_two_phase_workdir(tmp_path))
+        model = _section(md, "model.r1.i1")
+        sh = next(l for l in model.splitlines() if "shared.txt" in l)
+        assert "modified from inherited" in sh
+
+    def test_basename_collision_not_treated_as_inherited(self, tmp_path: Path) -> None:
+        md, _ = build_digest(_two_phase_workdir(tmp_path))
+        model = _section(md, "model.r1.i1")
+        # both prep and model write their own summary.md; root has none →
+        # model's is produced, NOT a false "modified from inherited"
+        sm = next(l for l in model.splitlines() if "summary.md" in l)
+        assert "modified from inherited" not in sm
+        assert "out.txt" in model  # its own product
+
+    def test_consolidator_workdir_does_not_swallow_instances(self, tmp_path: Path) -> None:
+        # A consolidator whose base is the run root must not list instance files.
+        wd = tmp_path / "cons"
+        logs = wd / "_opencode_logs" / "poet-parallel-run-500"
+        logs.mkdir(parents=True)
+        (logs / "instance-1.log").write_text(
+            _line("dlab_start", 500, model="m", agent="poet") + "\n")
+        (logs / "consolidator.log").write_text(
+            _line("dlab_start", 900, model="m", agent="consolidator") + "\n")
+        inst = wd / "parallel" / "run-500" / "instance-1"
+        inst.mkdir(parents=True)
+        (inst / "poem.txt").write_text("a poem")
+        (wd / "parallel" / "run-500" / "consolidated_summary.md").write_text("cmp")
+        md, _ = build_digest(wd)
+        cons = _section(md, "poet.r1.cons")
+        assert "poem.txt" not in cons  # sibling's file, not the consolidator's
 
 
 def _have_node() -> bool:

--- a/tests/test_session_digest.py
+++ b/tests/test_session_digest.py
@@ -442,6 +442,52 @@ class TestComposerFeedbackFixes:
         assert "NO consolidated_summary.md" not in md2
 
 
+def _artifacts_workdir(tmp_path: Path) -> Path:
+    wd = tmp_path / "art"
+    logs = wd / "_opencode_logs"
+    logs.mkdir(parents=True)
+    (logs / "main.log").write_text("\n".join([
+        _line("dlab_start", 1000, model="m", agent="main"),
+        _line("tool_use", 1100, part={"tool": "bash", "state": {
+            "status": "completed", "input": {"command": "python run.py"},
+            "output": "done", "time": {"start": 1100, "end": 3000}}}),
+    ]) + "\n")
+    (wd / "metrics.json").write_text(json.dumps({"r2": 0.84, "mape": 9.3, "ess": 965}))
+    (wd / "roas.csv").write_text("channel,roas\nEmail,25.5\nSearch,11.0\n")
+    (wd / "report.md").write_text("# Big Title\n\nsome text\nmore\n")
+    (wd / "model.nc").write_bytes(b"\x00" * 100)      # binary ext → not indexed
+    (wd / "huge.txt").write_text("x\n" * 40000)        # >32KB text → not indexed
+    return wd
+
+
+class TestArtifactRetrieval:
+    def test_shapes_rendered(self, tmp_path: Path) -> None:
+        md, _ = build_digest(_artifacts_workdir(tmp_path))
+        rows = {l.split("]")[1].split("(")[0].strip(): l
+                for l in md.splitlines() if l.strip().startswith("- [a")}
+        assert "keys: r2, mape, ess" in rows["metrics.json"]
+        assert "cols: channel, roas; 2 rows" in rows["roas.csv"]
+        assert "lines — Big Title" in rows["report.md"]
+
+    def test_small_text_indexed_big_and_binary_excluded(self, tmp_path: Path) -> None:
+        _, index = build_digest(_artifacts_workdir(tmp_path))
+        paths = {v["log_file"] for v in index.values()
+                 if v["event_type"] == "artifact"}
+        assert {"metrics.json", "roas.csv", "report.md"} <= paths
+        assert "model.nc" not in paths   # binary extension
+        assert "huge.txt" not in paths   # over the 32KB cap
+
+    def test_artifact_index_points_to_readable_file(self, tmp_path: Path) -> None:
+        wd = _artifacts_workdir(tmp_path)
+        _, index = build_digest(wd)
+        entry = next(v for v in index.values()
+                     if v["event_type"] == "artifact" and v["log_file"] == "roas.csv")
+        assert "channel,roas" in (wd / entry["log_file"]).read_text()
+
+    def test_digest_get_source_handles_artifacts(self) -> None:
+        assert 'event_type === "artifact"' in DIGEST_GET_SOURCE
+
+
 def _have_node() -> bool:
     try:
         subprocess.run(["node", "--version"], capture_output=True, timeout=5)


### PR DESCRIPTION
Implements the deterministic **session digest** (#85) — the notebook composer's LLM-facing map of a completed run — plus the `dlab digest` CLI surface and the provenance-first redesign that came out of stress-testing it against a real MMM run.

_Filed by Claude on Ben's behalf._

## What's in it

- **`dlab/session_digest.py`** — `build_digest()` / `generate_digest()`. Deterministic, no LLM. Per-agent `###` sections on a shared `t`/`x`/`r` event counter; workflow tree; final artifacts.
- **`dlab digest [WORK_DIR] [--brief] [--write]`** — prints the digest, or `--write`s the `_digest/{digest.md,index.json}` pair the composer consumes.
- **Artifact attribution** — every artifact links to the tool call that produced it (`← written tN` / `← from tN` via mtime-in-window); the parent's `cp`'d files show, linked to the copy; untouched inherited copies are dropped by sha256 (creators keep their own file even when the root has an identical copy).
- **Labeled tool calls** — every producing call (bash, write, edit, and custom tools: `fit-model-modal`, `analyze-model`, `optimize-budget`) is an addressable row with status, duration, a compact input signature, and its mapped `raw_text`. Navigational calls stay a count line.
- **`raw_text` as first-class `r`-ids** — the stdout/stderr the run emits outside tool events (the majority of a real log — tracebacks, sampler output) is mapped to its call and retrievable; it's what the composer embeds as a cell's stream output.
- **Retrievable small text artifacts** — `.json/.csv/.md` (≤32KB) get a shape hint + a retrievable `a`-id, so per-instance metrics are readable; big/binary files stay pointers.
- **`dlab/js/digest-get.ts`** — the in-container retrieval tool (t/x/r/a ids, line ranges, decoded + sliced, LSP noise stripped).

## Validation

An LLM composed notebooks from the digest alone (no raw-log access) on `dlab-mmm-agent-oc-workdir-008` and critiqued the format; its feedback drove the input-signatures / error-tails / consolidator-flag / LSP-strip / artifact-retrieval fixes here. Spec §7 (`.claude/specs/notebook-composer.md`) is updated to match, with §7.4 recording the experiment. One finding was a dpack defect, filed as #88.

Tests: `tests/test_session_digest.py` (47 with `tests/test_sample_session.py`), plus the golden fixture. No mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)